### PR TITLE
Fix undefined function error in startApplication

### DIFF
--- a/main.js
+++ b/main.js
@@ -615,15 +615,6 @@ async function startApplication() {
       hideOverlappingPanels();
       updateTapeLooperUI();
       loadStateFromLocalStorage();
-      const pending = getPendingState();
-      if (pending) {
-        try {
-          loadState(pending);
-        } catch (e) {
-          console.warn('Failed to apply pending multiplayer state', e);
-        }
-        clearPendingState();
-      }
       startWithMode(selectedMode);
       if (isAudioReady && !isPlaying) {
         togglePlayPause();


### PR DESCRIPTION
## Summary
- remove leftover references to `getPendingState` and `clearPendingState` in `startApplication`

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d0329ad08832cb3baadddcc0371f7