### PR TITLE
Replace analog synth with Tone.js modules

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,4 @@
-import { fmSynthPresets } from './orbs/fm-synth-orb.js';
+import { fmSynthPresets, createToneFmSynthOrb, DEFAULT_TONE_FM_SYNTH_PARAMS } from './orbs/fm-synth-orb.js';
 import { analogWaveformPresets } from './orbs/analog-waveform-presets.js';
 import { createAnalogSynthOrb as createToneSynthOrb, DEFAULT_ANALOG_SYNTH_PARAMS } from './orbs/tone-synth-orb.js';
 import { showToneSynthMenu, hideToneSynthMenu, hideTonePanel } from './orbs/tone-synth-ui.js';
@@ -2317,7 +2317,9 @@ export function createAudioNodesForNode(node) {
 
           return audioNodes;
         } else if (node.type === "sound") {
-            if (node.audioParams && node.audioParams.engine === 'tone') {
+            if (node.audioParams && node.audioParams.engine === 'tonefm') {
+                return createToneFmSynthOrb(node);
+            } else if (node.audioParams && node.audioParams.engine === 'tone') {
                 return createToneSynthOrb(node);
             }
             const audioNodes = {
@@ -3740,7 +3742,7 @@ export function updateNodeAudioParams(node) {
 
     if (node.type === "sound") {
       if (lowPassFilter) {
-        if (node.audioParams && node.audioParams.engine === 'tone') {
+        if (node.audioParams && (node.audioParams.engine === 'tone' || node.audioParams.engine === 'tonefm')) {
           const cutoff = params.filterCutoff ?? MAX_FILTER_FREQ;
           lowPassFilter.frequency.setTargetAtTime(
             cutoff,
@@ -4385,7 +4387,7 @@ export function triggerNodeEffect(
     const orbitoneIndividualGains = audioNodes.orbitoneIndividualGains;
     const osc1Gain = audioNodes.osc1Gain;
 
-    if (node.audioParams && node.audioParams.engine === 'tone') {
+    if (node.audioParams && (node.audioParams.engine === 'tone' || node.audioParams.engine === 'tonefm')) {
       node.isTriggered = true;
       node.animationState = 1;
 
@@ -16542,10 +16544,10 @@ function handleMouseUp(event) {
           hideAlienOrbMenu();
           hideResonauterOrbMenu();
           hideArvoDroneOrbMenu();
-      } else if (selectedNode && selectedNode.type === "sound" && selectedNode.audioParams.engine === 'tone') {
-          showToneSynthMenu(selectedNode);
-          hideAlienOrbMenu();
-          hideResonauterOrbMenu();
+      } else if (selectedNode && selectedNode.type === "sound" && (selectedNode.audioParams.engine === 'tone' || selectedNode.audioParams.engine === 'tonefm')) {
+        showToneSynthMenu(selectedNode);
+        hideAlienOrbMenu();
+        hideResonauterOrbMenu();
           hideRadioOrbMenu();
           hideArvoDroneOrbMenu();
           hideSamplerOrbMenu();
@@ -19826,7 +19828,6 @@ function openReplaceInstrumentMenu() {
   groupDiv.classList.add("type-group");
 
   const instruments = [
-    { icon: "🎹", label: "Analog Synth", handler: () => populateReplacePresetMenu('analogWaveforms', 'Analog Synths') },
     { icon: "🔔", label: "FM Synth", handler: () => populateReplacePresetMenu('fmSynths', 'FM Synths') },
     { icon: "🛰️", label: "Sampler", handler: () => populateReplacePresetMenu('samplers', 'Samplers') },
     { icon: "🥁", label: "Drum", handler: () => populateReplacePresetMenu('drumElements', 'Drum Elements') },
@@ -19932,18 +19933,10 @@ function populateInstrumentMenu() {
 
   const instruments = [
     {
-      icon: "🎹",
-      label: "Analog Synth",
-      handler: () => {
-        soundEngineToAdd = null;
-        setupAddTool(null, "sound", true, "analogWaveforms", "Analog Synths");
-      },
-    },
-    {
       icon: "🔔",
       label: "FM Synth",
       handler: () => {
-        soundEngineToAdd = null;
+        soundEngineToAdd = "tonefm";
         setupAddTool(null, "sound", true, "fmSynths", "FM Synths");
       },
     },
@@ -20014,13 +20007,13 @@ function populateInstrumentMenu() {
         helpWizard &&
         !helpWizard.classList.contains("hidden") &&
         currentHelpStep === 3 &&
-        inst.label === "Analog Synth"
+        inst.label === "Tone Synth"
       ) {
         nextHelpStep();
       }
     });
-    if (inst.label === "Analog Synth") {
-      analogSynthBtn = btn;
+    if (inst.label === "Tone Synth") {
+      toneSynthBtn = btn;
       helpSteps[3].target = btn;
     }
     groupDiv.appendChild(btn);
@@ -21203,7 +21196,7 @@ function toggleHelpPopup() {
   }
 }
 
-let analogSynthBtn = null;
+let toneSynthBtn = null;
 let squareWaveBtn = null;
 const helpSteps = [
   {
@@ -21219,7 +21212,7 @@ const helpSteps = [
     target: instrumentsMenuBtn,
   },
   {
-    text: "Choose Analog Synth",
+    text: "Choose Tone Synth",
     target: null,
   },
   {
@@ -22533,6 +22526,13 @@ function addNode(x, y, type, subtype = null, optionalDimensions = null) {
         if (nodeSubtypeForAudioParams) {
           newNode.audioParams.osc1Waveform = nodeSubtypeForAudioParams;
         }
+      } else if (soundEngineToAdd === 'tonefm') {
+        const existing = { ...newNode.audioParams };
+        Object.assign(newNode.audioParams, DEFAULT_TONE_FM_SYNTH_PARAMS);
+        Object.assign(newNode.audioParams, existing);
+        if (nodeSubtypeForAudioParams) {
+          newNode.audioParams.carrierWaveform = nodeSubtypeForAudioParams;
+        }
       }
     }
   }
@@ -23331,20 +23331,20 @@ if (motionMenuBtn) {
 
 if (addAnalogSynthBtn) {
   addAnalogSynthBtn.addEventListener("click", (e) => {
-    soundEngineToAdd = null;
+    soundEngineToAdd = "tone";
     setupAddTool(
       e.currentTarget,
       "sound",
       true,
       "analogWaveforms",
-      "Analog Synths",
+      "Tone Synths",
     );
   });
 }
 
 if (addFmSynthBtn) {
   addFmSynthBtn.addEventListener("click", (e) => {
-    soundEngineToAdd = null;
+    soundEngineToAdd = "tonefm";
     setupAddTool(e.currentTarget, "sound", true, "fmSynths", "FM Synths");
   });
 }

--- a/orbs/fm-synth-orb.js
+++ b/orbs/fm-synth-orb.js
@@ -253,3 +253,4 @@ export function createFmSynthOrb(node) {
 
   return audioNodes;
 }
+export { createToneFmSynthOrb, DEFAULT_TONE_FM_SYNTH_PARAMS } from './tone-fm-synth-orb.js';

--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -1,0 +1,81 @@
+import * as Tone from 'tone';
+import { sanitizeWaveformType } from '../utils/oscillatorUtils.js';
+
+export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
+  carrierWaveform: 'sine',
+  modulatorWaveform: 'sine',
+  carrierRatio: 1,
+  modulatorRatio: 1,
+  modulatorDepthScale: 2,
+  carrierEnvAttack: 0.01,
+  carrierEnvDecay: 0.3,
+  carrierEnvSustain: 0,
+  carrierEnvRelease: 0.3,
+  modulatorEnvAttack: 0.01,
+  modulatorEnvDecay: 0.2,
+  modulatorEnvSustain: 0,
+  modulatorEnvRelease: 0.2,
+  reverbSend: 0.1,
+  delaySend: 0.1,
+  visualStyle: 'fm_default',
+  ignoreGlobalSync: false,
+};
+
+export function createToneFmSynthOrb(node) {
+  const p = node.audioParams;
+  const synth = new Tone.FMSynth({
+    oscillator: { type: sanitizeWaveformType(p.carrierWaveform) },
+    modulation: { type: sanitizeWaveformType(p.modulatorWaveform) },
+    harmonicity: p.modulatorRatio ?? 1,
+    modulationIndex: p.modulatorDepthScale ?? 2,
+    envelope: {
+      attack: p.carrierEnvAttack ?? 0.01,
+      decay: p.carrierEnvDecay ?? 0.3,
+      sustain: p.carrierEnvSustain ?? 0,
+      release: p.carrierEnvRelease ?? 0.3,
+    },
+    modulationEnvelope: {
+      attack: p.modulatorEnvAttack ?? 0.01,
+      decay: p.modulatorEnvDecay ?? 0.2,
+      sustain: p.modulatorEnvSustain ?? 0,
+      release: p.modulatorEnvRelease ?? 0.2,
+    },
+  }).toDestination();
+  synth.volume.value = -Infinity;
+
+  const reverbSendGain = new Tone.Gain(p.reverbSend ?? 0.1);
+  const delaySendGain = new Tone.Gain(p.delaySend ?? 0.1);
+  synth.connect(reverbSendGain);
+  synth.connect(delaySendGain);
+  if (globalThis.isReverbReady && globalThis.reverbPreDelayNode) {
+    reverbSendGain.connect(globalThis.reverbPreDelayNode);
+  }
+  if (globalThis.isDelayReady && globalThis.masterDelaySendGain) {
+    delaySendGain.connect(globalThis.masterDelaySendGain);
+  }
+  if (globalThis.mistEffectInput) {
+    const mistSendGain = new Tone.Gain(0);
+    synth.connect(mistSendGain);
+    mistSendGain.connect(globalThis.mistEffectInput);
+    synth.mistSendGain = mistSendGain;
+  }
+  if (globalThis.crushEffectInput) {
+    const crushSendGain = new Tone.Gain(0);
+    synth.connect(crushSendGain);
+    crushSendGain.connect(globalThis.crushEffectInput);
+    synth.crushSendGain = crushSendGain;
+  }
+
+  synth.reverbSendGain = reverbSendGain;
+  synth.delaySendGain = delaySendGain;
+
+  synth.triggerStart = (time, velocity = 1) => {
+    synth.volume.setValueAtTime(-6 * velocity, time);
+    synth.triggerAttack(Tone.now(), velocity);
+  };
+  synth.triggerStop = (time) => {
+    synth.triggerRelease(time);
+  };
+
+  return synth;
+}


### PR DESCRIPTION
## Summary
- remove unused analog synth option in menu
- add Tone.js FM synth implementation
- update instrument buttons and help wizard
- integrate Tone-based FM synth engine

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d145a92c0832c9bb71c2f4f08e82c