### PR TITLE
Replace analog synth with Tone.js modules

### DIFF
--- a/orbs/fm-synth-orb.js
+++ b/orbs/fm-synth-orb.js
@@ -253,3 +253,4 @@ export function createFmSynthOrb(node) {
 
   return audioNodes;
 }
+export { createToneFmSynthOrb, DEFAULT_TONE_FM_SYNTH_PARAMS } from './tone-fm-synth-orb.js';

--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -1,0 +1,81 @@
+import * as Tone from 'tone';
+import { sanitizeWaveformType } from '../utils/oscillatorUtils.js';
+
+export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
+  carrierWaveform: 'sine',
+  modulatorWaveform: 'sine',
+  carrierRatio: 1,
+  modulatorRatio: 1,
+  modulatorDepthScale: 2,
+  carrierEnvAttack: 0.01,
+  carrierEnvDecay: 0.3,
+  carrierEnvSustain: 0,
+  carrierEnvRelease: 0.3,
+  modulatorEnvAttack: 0.01,
+  modulatorEnvDecay: 0.2,
+  modulatorEnvSustain: 0,
+  modulatorEnvRelease: 0.2,
+  reverbSend: 0.1,
+  delaySend: 0.1,
+  visualStyle: 'fm_default',
+  ignoreGlobalSync: false,
+};
+
+export function createToneFmSynthOrb(node) {
+  const p = node.audioParams;
+  const synth = new Tone.FMSynth({
+    oscillator: { type: sanitizeWaveformType(p.carrierWaveform) },
+    modulation: { type: sanitizeWaveformType(p.modulatorWaveform) },
+    harmonicity: p.modulatorRatio ?? 1,
+    modulationIndex: p.modulatorDepthScale ?? 2,
+    envelope: {
+      attack: p.carrierEnvAttack ?? 0.01,
+      decay: p.carrierEnvDecay ?? 0.3,
+      sustain: p.carrierEnvSustain ?? 0,
+      release: p.carrierEnvRelease ?? 0.3,
+    },
+    modulationEnvelope: {
+      attack: p.modulatorEnvAttack ?? 0.01,
+      decay: p.modulatorEnvDecay ?? 0.2,
+      sustain: p.modulatorEnvSustain ?? 0,
+      release: p.modulatorEnvRelease ?? 0.2,
+    },
+  }).toDestination();
+  synth.volume.value = -Infinity;
+
+  const reverbSendGain = new Tone.Gain(p.reverbSend ?? 0.1);
+  const delaySendGain = new Tone.Gain(p.delaySend ?? 0.1);
+  synth.connect(reverbSendGain);
+  synth.connect(delaySendGain);
+  if (globalThis.isReverbReady && globalThis.reverbPreDelayNode) {
+    reverbSendGain.connect(globalThis.reverbPreDelayNode);
+  }
+  if (globalThis.isDelayReady && globalThis.masterDelaySendGain) {
+    delaySendGain.connect(globalThis.masterDelaySendGain);
+  }
+  if (globalThis.mistEffectInput) {
+    const mistSendGain = new Tone.Gain(0);
+    synth.connect(mistSendGain);
+    mistSendGain.connect(globalThis.mistEffectInput);
+    synth.mistSendGain = mistSendGain;
+  }
+  if (globalThis.crushEffectInput) {
+    const crushSendGain = new Tone.Gain(0);
+    synth.connect(crushSendGain);
+    crushSendGain.connect(globalThis.crushEffectInput);
+    synth.crushSendGain = crushSendGain;
+  }
+
+  synth.reverbSendGain = reverbSendGain;
+  synth.delaySendGain = delaySendGain;
+
+  synth.triggerStart = (time, velocity = 1) => {
+    synth.volume.setValueAtTime(-6 * velocity, time);
+    synth.triggerAttack(Tone.now(), velocity);
+  };
+  synth.triggerStop = (time) => {
+    synth.triggerRelease(time);
+  };
+
+  return synth;
+}


### PR DESCRIPTION
## Summary
- remove unused analog synth option in menu
- add Tone.js FM synth implementation
- update instrument buttons and help wizard
- integrate Tone-based FM synth engine
- fix Tone context initialization order

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d145a92c0832c9bb71c2f4f08e82c