### PR TITLE
Handle unsupported Tone.js context

### DIFF
--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -23,7 +23,13 @@ export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
 
 export function createToneFmSynthOrb(node) {
   const p = node.audioParams;
-  const synth = new Tone.FMSynth().toDestination();
+  let synth;
+  try {
+    synth = new Tone.FMSynth().toDestination();
+  } catch (e) {
+    console.warn('Tone.FMSynth could not be created in this environment:', e);
+    return null;
+  }
   synth.volume.value = -Infinity;
 
   synth.set({


### PR DESCRIPTION
## Summary
- Guard Tone.FMSynth creation and return null when the environment lacks a proper AudioParam-based context

## Testing
- `npm ci`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_688da35371fc832c8393e5c4d028f397