### PR TITLE
Add basic FM synth presets

### DIFF
--- a/orbs/fm-synth-orb.js
+++ b/orbs/fm-synth-orb.js
@@ -1,2 +1,43 @@
-export const fmSynthPresets = [];
+export const fmSynthPresets = [
+  {
+    type: 'sine',
+    label: 'Sine',
+    icon: '○',
+    details: {
+      visualStyle: 'fm_default',
+      carrierWaveform: 'sine',
+      modulatorWaveform: 'sine',
+    },
+  },
+  {
+    type: 'square',
+    label: 'Square',
+    icon: '□',
+    details: {
+      visualStyle: 'fm_default',
+      carrierWaveform: 'square',
+      modulatorWaveform: 'square',
+    },
+  },
+  {
+    type: 'sawtooth',
+    label: 'Saw',
+    icon: '📈',
+    details: {
+      visualStyle: 'fm_default',
+      carrierWaveform: 'sawtooth',
+      modulatorWaveform: 'sawtooth',
+    },
+  },
+  {
+    type: 'triangle',
+    label: 'Triangle',
+    icon: '△',
+    details: {
+      visualStyle: 'fm_default',
+      carrierWaveform: 'triangle',
+      modulatorWaveform: 'triangle',
+    },
+  },
+];
 export { createToneFmSynthOrb, DEFAULT_TONE_FM_SYNTH_PARAMS } from './tone-fm-synth-orb.js';


### PR DESCRIPTION
## Summary
- Provide default FM synth waveform presets so note selection appears and FM nodes can be placed

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a381c533d0832cb64e6aefa9bc2b17