### PR TITLE
Add basic FM synth presets

### DIFF
--- a/main.js
+++ b/main.js
@@ -4387,7 +4387,39 @@ export function triggerNodeEffect(
     const orbitoneIndividualGains = audioNodes.orbitoneIndividualGains;
     const osc1Gain = audioNodes.osc1Gain;
 
-    if (node.audioParams && (node.audioParams.engine === 'tone' || node.audioParams.engine === 'tonefm')) {
+    if (node.audioParams && node.audioParams.engine === 'tonefm') {
+      node.isTriggered = true;
+      node.animationState = 1;
+
+      const atk = params.carrierEnvAttack ?? 0.01;
+      const dec = params.carrierEnvDecay ?? 0.3;
+      const sus = params.carrierEnvSustain ?? 0;
+      const rel = params.carrierEnvRelease ?? 0.3;
+
+      if (oscillator1 && oscillator1.frequency) {
+        oscillator1.frequency.setValueAtTime(
+          effectivePitch * (params.carrierRatio ?? 1),
+          now,
+        );
+      }
+
+      if (audioNodes.triggerStart) {
+        audioNodes.triggerStart(now, intensity);
+      }
+
+      const noteOffTime = now + atk + dec + (sus > 0 ? 0.1 : 0);
+      if (audioNodes.triggerStop) {
+        audioNodes.triggerStop(noteOffTime);
+      }
+
+      setTimeout(() => {
+        const stillNode = findNodeById(node.id);
+        if (stillNode) stillNode.isTriggered = false;
+      }, (noteOffTime - now + rel) * 1000 + 100);
+      return;
+    }
+
+    if (node.audioParams && node.audioParams.engine === 'tone') {
       node.isTriggered = true;
       node.animationState = 1;
 

--- a/orbs/fm-synth-orb.js
+++ b/orbs/fm-synth-orb.js
@@ -1,2 +1,43 @@
-export const fmSynthPresets = [];
+export const fmSynthPresets = [
+  {
+    type: 'sine',
+    label: 'Sine',
+    icon: '○',
+    details: {
+      visualStyle: 'fm_default',
+      carrierWaveform: 'sine',
+      modulatorWaveform: 'sine',
+    },
+  },
+  {
+    type: 'square',
+    label: 'Square',
+    icon: '□',
+    details: {
+      visualStyle: 'fm_default',
+      carrierWaveform: 'square',
+      modulatorWaveform: 'square',
+    },
+  },
+  {
+    type: 'sawtooth',
+    label: 'Saw',
+    icon: '📈',
+    details: {
+      visualStyle: 'fm_default',
+      carrierWaveform: 'sawtooth',
+      modulatorWaveform: 'sawtooth',
+    },
+  },
+  {
+    type: 'triangle',
+    label: 'Triangle',
+    icon: '△',
+    details: {
+      visualStyle: 'fm_default',
+      carrierWaveform: 'triangle',
+      modulatorWaveform: 'triangle',
+    },
+  },
+];
 export { createToneFmSynthOrb, DEFAULT_TONE_FM_SYNTH_PARAMS } from './tone-fm-synth-orb.js';

--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -42,6 +42,9 @@ export function createToneFmSynthOrb(node) {
   }
   const carrier = audioContext.createOscillator();
   carrier.type = sanitizeWaveformType(p.carrierWaveform);
+  // Ensure the carrier starts at an audible pitch; this will be updated
+  // later when notes are triggered.
+  carrier.frequency.value = 440;
   const modulator = audioContext.createOscillator();
   modulator.type = sanitizeWaveformType(p.modulatorWaveform);
 
@@ -81,8 +84,13 @@ export function createToneFmSynthOrb(node) {
     ampGain.connect(crushSendGain);
     crushSendGain.connect(globalThis.crushEffectInput);
   }
+  // Route the FM synth output to the master bus if available, otherwise
+  // connect directly to the destination so the synth can still be heard
+  // even when the global master gain has not been initialised yet.
   if (globalThis.masterGain) {
     ampGain.connect(globalThis.masterGain);
+  } else {
+    ampGain.connect(audioContext.destination);
   }
 
   try { carrier.start(); } catch {}


### PR DESCRIPTION
## Summary
- Provide default FM synth waveform presets so note selection appears and FM nodes can be placed
- Route FM synth output to audio context when master gain is unavailable and initialise carrier oscillator to an audible frequency
- Trigger FM synth envelopes on playback so notes produce sound

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a381c533d0832cb64e6aefa9bc2b17