### PR TITLE
Use Tone.js FM engine for FM synth orb

### DIFF
--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -1,3 +1,4 @@
+import * as Tone from 'tone';
 import { sanitizeWaveformType } from '../utils/oscillatorUtils.js';
 
 export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
@@ -19,52 +20,37 @@ export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
   ignoreGlobalSync: false,
 };
 
-function applyEnvelope(param, attack, decay, sustain, release, time, velocity = 1) {
-  param.cancelScheduledValues(time);
-  param.setValueAtTime(0, time);
-  const peakTime = time + attack;
-  param.linearRampToValueAtTime(velocity, peakTime);
-  const sustainTime = peakTime + decay;
-  param.linearRampToValueAtTime(velocity * sustain, sustainTime);
-  return (stopTime) => {
-    param.cancelScheduledValues(stopTime);
-    param.setValueAtTime(param.value, stopTime);
-    param.linearRampToValueAtTime(0, stopTime + release);
-  };
-}
-
 export function createToneFmSynthOrb(node) {
   const p = node.audioParams;
-  if (typeof audioContext === 'undefined') {
-    console.warn('AudioContext not ready for FM synth');
-    return null;
-  }
-  const carrier = audioContext.createOscillator();
-  carrier.type = sanitizeWaveformType(p.carrierWaveform);
-  // Ensure the carrier starts at an audible pitch; this will be updated
-  // later when notes are triggered.
-  carrier.frequency.value = 440;
-  const modulator = audioContext.createOscillator();
-  modulator.type = sanitizeWaveformType(p.modulatorWaveform);
 
-  const modGain = audioContext.createGain();
-  modGain.gain.value = 0;
-  modulator.connect(modGain);
-  modGain.connect(carrier.frequency);
+  const fm = new Tone.FMSynth({
+    harmonicity: p.modulatorRatio ?? 1,
+    modulationIndex: p.modulatorDepthScale ?? 2,
+    oscillator: { type: sanitizeWaveformType(p.carrierWaveform) },
+    modulation: { type: sanitizeWaveformType(p.modulatorWaveform) },
+    envelope: {
+      attack: p.carrierEnvAttack ?? 0.01,
+      decay: p.carrierEnvDecay ?? 0.3,
+      sustain: p.carrierEnvSustain ?? 0,
+      release: p.carrierEnvRelease ?? 0.3,
+    },
+    modulationEnvelope: {
+      attack: p.modulatorEnvAttack ?? 0.01,
+      decay: p.modulatorEnvDecay ?? 0.2,
+      sustain: p.modulatorEnvSustain ?? 0,
+      release: p.modulatorEnvRelease ?? 0.2,
+    },
+  });
 
-  const lowPassFilter = audioContext.createBiquadFilter();
-  lowPassFilter.type = 'lowpass';
-  lowPassFilter.frequency.value = 20000;
+  const lowPassFilter = new Tone.Filter(20000, 'lowpass');
+  lowPassFilter.Q.value = 1;
+  fm.connect(lowPassFilter);
 
-  const gainNode = audioContext.createGain();
-  gainNode.gain.value = 0;
-  carrier.connect(lowPassFilter);
+  const gainNode = new Tone.Gain(1);
   lowPassFilter.connect(gainNode);
 
-  const reverbSendGain = audioContext.createGain();
-  reverbSendGain.gain.value = p.reverbSend ?? 0.1;
-  const delaySendGain = audioContext.createGain();
-  delaySendGain.gain.value = p.delaySend ?? 0.1;
+  const reverbSendGain = new Tone.Gain(p.reverbSend ?? 0.1);
+  const delaySendGain = new Tone.Gain(p.delaySend ?? 0.1);
   gainNode.connect(reverbSendGain);
   gainNode.connect(delaySendGain);
 
@@ -74,66 +60,39 @@ export function createToneFmSynthOrb(node) {
   if (globalThis.isDelayReady && globalThis.masterDelaySendGain) {
     delaySendGain.connect(globalThis.masterDelaySendGain);
   }
+
   let mistSendGain = null;
   if (globalThis.mistEffectInput) {
-    mistSendGain = audioContext.createGain();
-    mistSendGain.gain.value = 0;
+    mistSendGain = new Tone.Gain(0);
     gainNode.connect(mistSendGain);
     mistSendGain.connect(globalThis.mistEffectInput);
   }
+
   let crushSendGain = null;
   if (globalThis.crushEffectInput) {
-    crushSendGain = audioContext.createGain();
-    crushSendGain.gain.value = 0;
+    crushSendGain = new Tone.Gain(0);
     gainNode.connect(crushSendGain);
     crushSendGain.connect(globalThis.crushEffectInput);
   }
-  // Route the FM synth output to the master bus if available, otherwise
-  // connect directly to the destination so the synth can still be heard
-  // even when the global master gain has not been initialised yet.
+
   if (globalThis.masterGain) {
     gainNode.connect(globalThis.masterGain);
   } else {
-    gainNode.connect(audioContext.destination);
+    gainNode.connect(Tone.getContext().destination);
   }
 
-  try { carrier.start(); } catch {}
-  try { modulator.start(); } catch {}
-
   const triggerStart = (time, velocity = 1) => {
-    const baseFreq = carrier.frequency.value || 440;
-    modulator.frequency.setValueAtTime(baseFreq * (p.modulatorRatio ?? 1), time);
-    const stopAmpEnv = applyEnvelope(
-      gainNode.gain,
-      p.carrierEnvAttack ?? 0.01,
-      p.carrierEnvDecay ?? 0.3,
-      p.carrierEnvSustain ?? 0,
-      p.carrierEnvRelease ?? 0.3,
-      time,
-      velocity
-    );
-    const stopModEnv = applyEnvelope(
-      modGain.gain,
-      p.modulatorEnvAttack ?? 0.01,
-      p.modulatorEnvDecay ?? 0.2,
-      p.modulatorEnvSustain ?? 0,
-      p.modulatorEnvRelease ?? 0.2,
-      time,
-      p.modulatorDepthScale ?? 2
-    );
-    triggerStart.stopAmpEnv = stopAmpEnv;
-    triggerStart.stopModEnv = stopModEnv;
+    fm.triggerAttack(undefined, time, velocity);
   };
 
   const triggerStop = (time) => {
-    if (triggerStart.stopAmpEnv) triggerStart.stopAmpEnv(time);
-    if (triggerStart.stopModEnv) triggerStart.stopModEnv(time);
+    fm.triggerRelease(time);
   };
 
   return {
-    oscillator1: carrier,
-    modulatorOsc1: modulator,
-    modulatorGain1: modGain,
+    oscillator1: fm.oscillator,
+    modulatorOsc1: fm.modulation,
+    modulatorGain1: { gain: fm.modulationIndex },
     lowPassFilter,
     gainNode,
     reverbSendGain,


### PR DESCRIPTION
## Summary
- Replace custom Web Audio FM synth with Tone.js FMSynth
- Route synth through Tone-based filter and effect sends

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a484b9ccf0832ca1f567f0131b8223