### PR TITLE
Fix Tone.js FM synth note triggering

### DIFF
--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -82,7 +82,7 @@ export function createToneFmSynthOrb(node) {
   }
 
   const triggerStart = (time, velocity = 1) => {
-    fm.triggerAttack(undefined, time, velocity);
+    fm.triggerAttack(fm.frequency.value, time, velocity);
   };
 
   const triggerStop = (time) => {
@@ -90,7 +90,7 @@ export function createToneFmSynthOrb(node) {
   };
 
   return {
-    oscillator1: fm.oscillator,
+    oscillator1: fm,
     modulatorOsc1: fm.modulation,
     modulatorGain1: { gain: fm.modulationIndex },
     lowPassFilter,


### PR DESCRIPTION
## Summary
- ensure Tone.js FM synth triggers with current frequency
- expose FM synth as oscillator for main frequency control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4931f13d0832c80280bdb1282da11