### PR TITLE
Improve Tone FM synth controls

### DIFF
--- a/main.js
+++ b/main.js
@@ -3745,6 +3745,40 @@ export function updateNodeAudioParams(node) {
       modulatorOsc1.frequency.setTargetAtTime(base * params.modulatorRatio, now, generalUpdateTimeConstant);
     }
 
+    if (
+      node.audioParams &&
+      node.audioParams.engine === 'tonefm' &&
+      modulatorGain1 &&
+      params.modulatorDepthScale !== undefined
+    ) {
+      modulatorGain1.gain.setTargetAtTime(
+        params.modulatorDepthScale * 10,
+        now,
+        generalUpdateTimeConstant,
+      );
+    }
+
+    if (
+      node.audioParams &&
+      node.audioParams.engine === 'tonefm' &&
+      oscillator1 &&
+      oscillator1.envelope &&
+      oscillator1.modulationEnvelope
+    ) {
+      oscillator1.envelope.attack = params.carrierEnvAttack ?? oscillator1.envelope.attack;
+      oscillator1.envelope.decay = params.carrierEnvDecay ?? oscillator1.envelope.decay;
+      oscillator1.envelope.sustain = params.carrierEnvSustain ?? oscillator1.envelope.sustain;
+      oscillator1.envelope.release = params.carrierEnvRelease ?? oscillator1.envelope.release;
+      oscillator1.modulationEnvelope.attack =
+        params.modulatorEnvAttack ?? params.carrierEnvAttack ?? oscillator1.modulationEnvelope.attack;
+      oscillator1.modulationEnvelope.decay =
+        params.modulatorEnvDecay ?? params.carrierEnvDecay ?? oscillator1.modulationEnvelope.decay;
+      oscillator1.modulationEnvelope.sustain =
+        params.modulatorEnvSustain ?? 1;
+      oscillator1.modulationEnvelope.release =
+        params.modulatorEnvRelease ?? params.carrierEnvRelease ?? oscillator1.modulationEnvelope.release;
+    }
+
     if (node.audioNodes.noiseGain) {
       node.audioNodes.noiseGain.gain.setTargetAtTime(
         params.noiseLevel ?? 0,

--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -5,15 +5,15 @@ export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
   carrierWaveform: 'sine',
   modulatorWaveform: 'sine',
   modulatorRatio: 1,
-  modulatorDepthScale: 2,
+  modulatorDepthScale: 1,
   carrierEnvAttack: 0.01,
   carrierEnvDecay: 0.3,
   carrierEnvSustain: 0,
   carrierEnvRelease: 0.3,
-  modulatorEnvAttack: 0.01,
-  modulatorEnvDecay: 0.2,
-  modulatorEnvSustain: 0,
-  modulatorEnvRelease: 0.2,
+  modulatorEnvAttack: null,
+  modulatorEnvDecay: null,
+  modulatorEnvSustain: 1,
+  modulatorEnvRelease: null,
   reverbSend: 0.1,
   delaySend: 0.1,
   visualStyle: 'fm_default',
@@ -25,7 +25,7 @@ export function createToneFmSynthOrb(node) {
 
   const fm = new Tone.FMSynth({
     harmonicity: p.modulatorRatio ?? 1,
-    modulationIndex: p.modulatorDepthScale ?? 2,
+    modulationIndex: (p.modulatorDepthScale ?? 1) * 10,
     oscillator: { type: sanitizeWaveformType(p.carrierWaveform) },
     modulation: { type: sanitizeWaveformType(p.modulatorWaveform) },
     envelope: {
@@ -35,10 +35,10 @@ export function createToneFmSynthOrb(node) {
       release: p.carrierEnvRelease ?? 0.3,
     },
     modulationEnvelope: {
-      attack: p.modulatorEnvAttack ?? 0.01,
-      decay: p.modulatorEnvDecay ?? 0.2,
-      sustain: p.modulatorEnvSustain ?? 0,
-      release: p.modulatorEnvRelease ?? 0.2,
+      attack: p.modulatorEnvAttack ?? p.carrierEnvAttack ?? 0.01,
+      decay: p.modulatorEnvDecay ?? p.carrierEnvDecay ?? 0.3,
+      sustain: p.modulatorEnvSustain ?? 1,
+      release: p.modulatorEnvRelease ?? p.carrierEnvRelease ?? 0.3,
     },
   });
 

--- a/orbs/tone-fm-synth-ui.js
+++ b/orbs/tone-fm-synth-ui.js
@@ -81,9 +81,9 @@ export function showToneFmSynthMenu(node) {
     0,
     10,
     0.1,
-    node.audioParams.modulatorDepthScale ?? 2,
+    node.audioParams.modulatorDepthScale ?? 1,
     v => { node.audioParams.modulatorDepthScale = v; updateNodeAudioParams(node); },
-    v => v.toFixed(1)
+    v => (v * 10).toFixed(1)
   );
   container.appendChild(depthSlider);
 


### PR DESCRIPTION
## Summary
- Scale FM synth modulation depth for stronger timbral changes
- Tie modulation envelope to carrier envelope and keep modulation sustained
- Update UI slider formatting for clearer depth control

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5ca648d20832c9f2e30fad0cbbb2c