### PR TITLE
Add configurable filter to FM synth presets

### DIFF
--- a/orbs/fm-synth-orb.js
+++ b/orbs/fm-synth-orb.js
@@ -17,6 +17,8 @@ export const fmSynthPresets = [
       modulatorEnvDecay: 1.0,
       modulatorEnvSustain: 0,
       modulatorEnvRelease: 1.0,
+      filterCutoff: 8000,
+      filterResonance: 1,
     },
   },
   {
@@ -37,6 +39,8 @@ export const fmSynthPresets = [
       modulatorEnvDecay: 0.3,
       modulatorEnvSustain: 0,
       modulatorEnvRelease: 0.3,
+      filterCutoff: 8000,
+      filterResonance: 1,
     },
   },
   {
@@ -57,6 +61,8 @@ export const fmSynthPresets = [
       modulatorEnvDecay: 0.4,
       modulatorEnvSustain: 0,
       modulatorEnvRelease: 0.3,
+      filterCutoff: 8000,
+      filterResonance: 1,
     },
   },
   {
@@ -77,6 +83,8 @@ export const fmSynthPresets = [
       modulatorEnvDecay: 0.3,
       modulatorEnvSustain: 0.3,
       modulatorEnvRelease: 0.6,
+      filterCutoff: 5000,
+      filterResonance: 1,
     },
   },
   {
@@ -97,6 +105,8 @@ export const fmSynthPresets = [
       modulatorEnvDecay: 0.3,
       modulatorEnvSustain: 0.5,
       modulatorEnvRelease: 1.2,
+      filterCutoff: 6000,
+      filterResonance: 1,
     },
   },
 ];

--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -14,6 +14,9 @@ export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
   modulatorEnvDecay: null,
   modulatorEnvSustain: 1,
   modulatorEnvRelease: null,
+  filterType: 'lowpass',
+  filterCutoff: 20000,
+  filterResonance: 1,
   reverbSend: 0.1,
   delaySend: 0.1,
   visualStyle: 'fm_default',
@@ -42,12 +45,12 @@ export function createToneFmSynthOrb(node) {
     },
   });
 
-  const lowPassFilter = new Tone.Filter(20000, 'lowpass');
-  lowPassFilter.Q.value = 1;
-  fm.connect(lowPassFilter);
+  const filter = new Tone.Filter(p.filterCutoff ?? 20000, p.filterType ?? 'lowpass');
+  filter.Q.value = p.filterResonance ?? 1;
+  fm.connect(filter);
 
   const gainNode = new Tone.Gain(1);
-  lowPassFilter.connect(gainNode);
+  filter.connect(gainNode);
 
   const reverbSendGain = new Tone.Gain(p.reverbSend ?? 0.1);
   const delaySendGain = new Tone.Gain(p.delaySend ?? 0.1);
@@ -93,7 +96,7 @@ export function createToneFmSynthOrb(node) {
     oscillator1: fm,
     modulatorOsc1: fm.modulation,
     modulatorGain1: { gain: fm.modulationIndex },
-    lowPassFilter,
+    lowPassFilter: filter,
     gainNode,
     reverbSendGain,
     delaySendGain,


### PR DESCRIPTION
## Summary
- allow FM synths to specify filter type, cutoff, and resonance
- supply filter parameters for built-in FM presets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5cf5609bc832ca64ff3f7ce8fa4cf