### PR TITLE
Expose filter and operator controls for FM synth

### DIFF
--- a/main.js
+++ b/main.js
@@ -3762,6 +3762,20 @@ export function updateNodeAudioParams(node) {
       node.audioParams &&
       node.audioParams.engine === 'tonefm' &&
       oscillator1 &&
+      oscillator1.detune &&
+      params.detune !== undefined
+    ) {
+      oscillator1.detune.setTargetAtTime(
+        params.detune,
+        now,
+        generalUpdateTimeConstant,
+      );
+    }
+
+    if (
+      node.audioParams &&
+      node.audioParams.engine === 'tonefm' &&
+      oscillator1 &&
       oscillator1.envelope &&
       oscillator1.modulationEnvelope
     ) {
@@ -3790,6 +3804,9 @@ export function updateNodeAudioParams(node) {
     if (node.type === "sound") {
       if (lowPassFilter) {
         if (node.audioParams && (node.audioParams.engine === 'tone' || node.audioParams.engine === 'tonefm')) {
+          if (params.filterType) {
+            lowPassFilter.type = params.filterType;
+          }
           const cutoff = params.filterCutoff ?? MAX_FILTER_FREQ;
           lowPassFilter.frequency.setTargetAtTime(
             cutoff,

--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -17,6 +17,7 @@ export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
   filterType: 'lowpass',
   filterCutoff: 20000,
   filterResonance: 1,
+  detune: 0,
   reverbSend: 0.1,
   delaySend: 0.1,
   visualStyle: 'fm_default',
@@ -44,6 +45,8 @@ export function createToneFmSynthOrb(node) {
       release: p.modulatorEnvRelease ?? p.carrierEnvRelease ?? 0.3,
     },
   });
+
+  fm.detune.value = p.detune ?? 0;
 
   const filter = new Tone.Filter(p.filterCutoff ?? 20000, p.filterType ?? 'lowpass');
   filter.Q.value = p.filterResonance ?? 1;

--- a/orbs/tone-fm-synth-ui.js
+++ b/orbs/tone-fm-synth-ui.js
@@ -111,6 +111,62 @@ export function showToneFmSynthMenu(node) {
   });
   container.appendChild(envRow);
 
+  const filterTypeWrap = document.createElement('div');
+  const filterTypeLabel = document.createElement('label');
+  filterTypeLabel.textContent = 'Filt';
+  const filterTypeSelect = document.createElement('select');
+  ['lowpass', 'highpass', 'bandpass'].forEach(t => {
+    const opt = document.createElement('option');
+    opt.value = t;
+    opt.textContent = t;
+    if (node.audioParams.filterType === t) opt.selected = true;
+    filterTypeSelect.appendChild(opt);
+  });
+  filterTypeSelect.addEventListener('change', e => {
+    node.audioParams.filterType = e.target.value;
+    updateNodeAudioParams(node);
+  });
+  filterTypeWrap.appendChild(filterTypeLabel);
+  filterTypeWrap.appendChild(filterTypeSelect);
+  filterTypeWrap.style.marginTop = '6px';
+  container.appendChild(filterTypeWrap);
+
+  const cutoffSlider = createSlider(
+    `fm-filterCutoff-${node.id}`,
+    'Cutoff',
+    100,
+    20000,
+    100,
+    node.audioParams.filterCutoff ?? 20000,
+    v => { node.audioParams.filterCutoff = v; updateNodeAudioParams(node); },
+    v => Math.round(v)
+  );
+  container.appendChild(cutoffSlider);
+
+  const resSlider = createSlider(
+    `fm-filterResonance-${node.id}`,
+    'Res',
+    0.1,
+    20,
+    0.1,
+    node.audioParams.filterResonance ?? 1,
+    v => { node.audioParams.filterResonance = v; updateNodeAudioParams(node); },
+    v => v.toFixed(1)
+  );
+  container.appendChild(resSlider);
+
+  const detuneSlider = createSlider(
+    `fm-detune-${node.id}`,
+    'Detune',
+    -1200,
+    1200,
+    1,
+    node.audioParams.detune ?? 0,
+    v => { node.audioParams.detune = v; updateNodeAudioParams(node); },
+    v => v.toFixed(0)
+  );
+  container.appendChild(detuneSlider);
+
   positionTonePanel(node);
 }
 


### PR DESCRIPTION
## Summary
- add detune and filter defaults to Tone FM synth
- handle detune and filter type updates in audio param handler
- expose filter and detune controls in FM synth UI

## Testing
- `npm ci`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a80fa63f70832caba2ae28a150eb34