### PR TITLE
feat: add algorithm selection buttons to FM synths

### DIFF
--- a/orbs/fm-synth-orb.js
+++ b/orbs/fm-synth-orb.js
@@ -111,4 +111,8 @@ export const fmSynthPresets = [
   },
 ];
 
-export { createToneFmSynthOrb, DEFAULT_TONE_FM_SYNTH_PARAMS } from './tone-fm-synth-orb.js';
+export {
+  createToneFmSynthOrb,
+  DEFAULT_TONE_FM_SYNTH_PARAMS,
+  fmAlgorithms,
+} from './tone-fm-synth-orb.js';

--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -6,6 +6,7 @@ export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
   modulatorWaveform: 'sine',
   modulatorRatio: 1,
   modulatorDepthScale: 1,
+  algorithm: 0,
   carrierEnvAttack: 0.01,
   carrierEnvDecay: 0.3,
   carrierEnvSustain: 0,
@@ -23,6 +24,13 @@ export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
   visualStyle: 'fm_default',
   ignoreGlobalSync: false,
 };
+
+export const fmAlgorithms = [
+  { label: 'Alg 1', modulatorRatio: 1, modulatorDepthScale: 1 },
+  { label: 'Alg 2', modulatorRatio: 2, modulatorDepthScale: 1 },
+  { label: 'Alg 3', modulatorRatio: 3, modulatorDepthScale: 2 },
+  { label: 'Alg 4', modulatorRatio: 2, modulatorDepthScale: 4 },
+];
 
 export function createToneFmSynthOrb(node) {
   const p = node.audioParams;

--- a/orbs/tone-fm-synth-ui.js
+++ b/orbs/tone-fm-synth-ui.js
@@ -1,6 +1,7 @@
 import { tonePanelContent } from '../utils/domElements.js';
 import { updateNodeAudioParams } from '../main.js';
 import { showTonePanel, positionTonePanel, hideToneSynthMenu } from './tone-synth-ui.js';
+import { fmAlgorithms } from './fm-synth-orb.js';
 
 function createSlider(id, labelText, min, max, step, value, onInput, format = v => v.toFixed(step.toString().includes('.') ? step.toString().split('.')[1].length : 0)) {
   const wrap = document.createElement('div');
@@ -74,6 +75,7 @@ export function showToneFmSynthMenu(node) {
     v => v.toFixed(1)
   );
   container.appendChild(ratioSlider);
+  const ratioSliderInput = ratioSlider.querySelector('input');
 
   const depthSlider = createSlider(
     `fm-modDepth-${node.id}`,
@@ -86,6 +88,31 @@ export function showToneFmSynthMenu(node) {
     v => (v * 10).toFixed(1)
   );
   container.appendChild(depthSlider);
+  const depthSliderInput = depthSlider.querySelector('input');
+
+  const algRow = document.createElement('div');
+  algRow.style.display = 'flex';
+  algRow.style.marginTop = '6px';
+  fmAlgorithms.forEach((alg, idx) => {
+    const btn = document.createElement('button');
+    btn.textContent = alg.label || `Alg ${idx + 1}`;
+    btn.className = 'waveform-button';
+    btn.style.marginRight = '4px';
+    if (node.audioParams.algorithm === idx) btn.classList.add('selected');
+    btn.addEventListener('click', () => {
+      node.audioParams.algorithm = idx;
+      node.audioParams.modulatorRatio = alg.modulatorRatio;
+      node.audioParams.modulatorDepthScale = alg.modulatorDepthScale;
+      ratioSliderInput.value = alg.modulatorRatio;
+      ratioSliderInput.dispatchEvent(new Event('input'));
+      depthSliderInput.value = alg.modulatorDepthScale;
+      depthSliderInput.dispatchEvent(new Event('input'));
+      Array.from(algRow.children).forEach(c => c.classList.remove('selected'));
+      btn.classList.add('selected');
+    });
+    algRow.appendChild(btn);
+  });
+  container.appendChild(algRow);
 
   const carEnvLabel = document.createElement('div');
   carEnvLabel.textContent = 'Car Env';


### PR DESCRIPTION
## Summary
- add predefined FM algorithms and expose via UI buttons
- allow selecting algorithms to adjust modulator ratio and depth in FM synth

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a83041d954832ca3cf3cacf9474a1e