### PR TITLE
Enable random note by default when placing orbs

### DIFF
--- a/main.js
+++ b/main.js
@@ -17059,14 +17059,9 @@ function createHexNoteSelectorDOM(
       currentSelectedValue = null;
     }
   } else {
-    if (noteIndexToAdd !== -1) {
-      currentSelectedValue = noteIndexToAdd;
-      isRandomActive = false;
-    } else {
-      currentSelectedValue = null;
-      isRandomActive = true;
-      noteIndexToAdd = -1;
-    }
+    currentSelectedValue = null;
+    isRandomActive = true;
+    noteIndexToAdd = -1;
   }
 
   const randomToggleButton = document.createElement("button");


### PR DESCRIPTION
## Summary
- Reset note selector to random mode when adding orbs so placement is immediately possible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a870f81b18832cb4df619cca2234f5