### PR TITLE
feat: replace fm synth sliders with nexus dials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "nexusui": "^2.1.6",
         "tone": "^15.1.22"
       },
       "devDependencies": {
@@ -1123,6 +1124,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/nexusui": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/nexusui/-/nexusui-2.1.6.tgz",
+      "integrity": "sha512-tAtYZE82R8wvOp1GeW59TWCjSZksI5OVr+yS7tvF0LXOQnWkQW/WWCa7nqPeVXU7m1L3YjS+w76SnglpGOjA3w==",
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "nexusui": "^2.1.6",
     "tone": "^15.1.22"
   }
 }


### PR DESCRIPTION
## Summary
- add NexusUI dependency
- render FM synth ratio and depth controls with NexusUI dials
- update algorithm buttons to drive new dials

## Testing
- `npm ci`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a87b50737c832c921003a4cf478492