### PR TITLE
Add detune controls for FM synth operators

### DIFF
--- a/main.js
+++ b/main.js
@@ -3790,9 +3790,33 @@ export function updateNodeAudioParams(node) {
           generalUpdateTimeConstant,
         );
       }
-      if (oscillator1 && oscillator1.detune && params.detune !== undefined) {
-        oscillator1.detune.setTargetAtTime(
-          params.detune,
+      if (oscillator1 && oscillator1.detune) {
+        const det = params.carrierDetune ?? params.detune;
+        if (det !== undefined) {
+          oscillator1.detune.setTargetAtTime(
+            det,
+            now,
+            generalUpdateTimeConstant,
+          );
+        }
+      }
+      if (modulatorOsc1 && modulatorOsc1.detune && params.modulatorDetune !== undefined) {
+        modulatorOsc1.detune.setTargetAtTime(
+          params.modulatorDetune,
+          now,
+          generalUpdateTimeConstant,
+        );
+      }
+      if (modulatorOsc2 && modulatorOsc2.detune && params.modulator2Detune !== undefined) {
+        modulatorOsc2.detune.setTargetAtTime(
+          params.modulator2Detune,
+          now,
+          generalUpdateTimeConstant,
+        );
+      }
+      if (modulatorOsc3 && modulatorOsc3.detune && params.modulator3Detune !== undefined) {
+        modulatorOsc3.detune.setTargetAtTime(
+          params.modulator3Detune,
           now,
           generalUpdateTimeConstant,
         );

--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -29,6 +29,10 @@ export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
   modulator3EnvDecay: null,
   modulator3EnvSustain: 1,
   modulator3EnvRelease: null,
+  carrierDetune: 0,
+  modulatorDetune: 0,
+  modulator2Detune: 0,
+  modulator3Detune: 0,
   filterType: 'lowpass',
   filterCutoff: 20000,
   filterResonance: 1,
@@ -115,6 +119,7 @@ export function createToneFmSynthOrb(node) {
       type: sanitizeWaveformType(p[`${prefix}Waveform`]) || 'sine',
       frequency: 440,
     });
+    osc.detune.value = p[`${prefix}Detune`] ?? (prefix === 'carrier' ? p.detune ?? 0 : 0);
     const env = new Tone.Envelope({
       attack: p[`${prefix}EnvAttack`] ?? p[`${envFallback}EnvAttack`] ?? 0.01,
       decay: p[`${prefix}EnvDecay`] ?? p[`${envFallback}EnvDecay`] ?? 0.3,
@@ -213,7 +218,10 @@ export function createToneFmSynthOrb(node) {
     op4.env.triggerRelease(time);
   };
 
-  op1.osc.detune.value = p.detune ?? 0;
+  op1.osc.detune.value = p.carrierDetune ?? p.detune ?? 0;
+  op2.osc.detune.value = p.modulatorDetune ?? 0;
+  op3.osc.detune.value = p.modulator2Detune ?? 0;
+  op4.osc.detune.value = p.modulator3Detune ?? 0;
 
   return {
     oscillator1: op1.osc,

--- a/orbs/tone-fm-synth-ui.js
+++ b/orbs/tone-fm-synth-ui.js
@@ -168,7 +168,6 @@ export async function showToneFmSynthMenu(node) {
 
   const dialsGrid = document.createElement('div');
   dialsGrid.style.display = 'grid';
-  dialsGrid.style.gridTemplateColumns = 'repeat(6, 40px)';
   dialsGrid.style.gap = '4px';
   container.appendChild(dialsGrid);
 
@@ -209,8 +208,11 @@ export async function showToneFmSynthMenu(node) {
     { suffix: 'EnvRelease', short: 'R', min: 0, max: 4, step: 0.01, format: v => v.toFixed(2) },
     { suffix: 'Ratio', short: 'Rat', min: 0.1, max: 10, step: 0.1, format: v => v.toFixed(1) },
     { suffix: 'DepthScale', short: 'Dep', min: 0, max: 10, step: 0.1, format: v => (v * 10).toFixed(1) },
+    { suffix: 'Detune', short: 'Det', min: -1200, max: 1200, step: 1, format: v => v.toFixed(0) },
     { suffix: 'Waveform', short: 'W', type: 'select', options: ['sine', 'square', 'triangle', 'sawtooth'] },
   ];
+
+  dialsGrid.style.gridTemplateColumns = `repeat(${columns.length}, 40px)`;
 
   for (const op of operators) {
     for (const col of columns) {
@@ -255,7 +257,6 @@ export async function showToneFmSynthMenu(node) {
   const extras = [
     { key: 'filterCutoff', label: 'Cut', min: 100, max: 20000, step: 100, format: v => Math.round(v) },
     { key: 'filterResonance', label: 'Res', min: 0.1, max: 20, step: 0.1, format: v => v.toFixed(1) },
-    { key: 'detune', label: 'Det', min: -1200, max: 1200, step: 1, format: v => v.toFixed(0) },
     { key: 'filterType', label: 'Filt', type: 'select', options: ['lowpass', 'highpass', 'bandpass'] },
   ];
 


### PR DESCRIPTION
## Summary
- allow carrier and modulators to be detuned independently
- expose detune knobs for each FM operator in the UI
- update audio engine to apply new detune parameters

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8e1b521ec832ca0a36b1a3644d0d9