### PR TITLE
Add oscilloscope to FM synth UI

### DIFF
--- a/orbs/tone-fm-synth-ui.js
+++ b/orbs/tone-fm-synth-ui.js
@@ -137,6 +137,20 @@ export async function showToneFmSynthMenu(node) {
   displayWrap.style.gap = '4px';
   displayWrap.style.marginBottom = '4px';
 
+  // Small oscilloscope showing the synth output
+  if (Nexus && node.orb?.gainNode) {
+    const oscTarget = document.createElement('div');
+    oscTarget.style.width = '80px';
+    oscTarget.style.height = '30px';
+    displayWrap.appendChild(oscTarget);
+    const oscilloscope = new Nexus.Oscilloscope(oscTarget, { size: [80, 30] });
+    applyDialTheme(oscilloscope);
+    fmDials.add(oscilloscope);
+    initThemeObserver();
+    const srcNode = node.orb.gainNode._gainNode || node.orb.gainNode;
+    oscilloscope.connect(srcNode);
+  }
+
   const displayLabel = document.createElement('div');
   displayLabel.style.fontSize = '10px';
   displayWrap.appendChild(displayLabel);


### PR DESCRIPTION
## Summary
- Show FM synth output with a small NexusUI oscilloscope beside parameter display

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9506f6e10832cb7809894c4535fcd