### PR TITLE
Ensure linked parameter changes refresh audio

### DIFF
--- a/main.js
+++ b/main.js
@@ -965,10 +965,20 @@ function makeParameterGroup() {
         g.nodeIds.forEach((id) => {
           const n = findNodeById(id);
           const nodeTarget = g.nodeParamTargets.get(id);
-          // Avoid recursively triggering the proxy by only setting
-          // the property if it already exists on the target object.
-          if (nodeTarget && Object.prototype.hasOwnProperty.call(nodeTarget, prop)) {
-            nodeTarget[prop] = value;
+          // Ensure each linked node's parameter object reflects the latest
+          // value so audio updates propagate immediately without triggering
+          // recursive proxy writes.
+          if (nodeTarget) {
+            if (Object.prototype.hasOwnProperty.call(nodeTarget, prop)) {
+              nodeTarget[prop] = value;
+            } else {
+              Object.defineProperty(nodeTarget, prop, {
+                value,
+                writable: true,
+                enumerable: true,
+                configurable: true,
+              });
+            }
           }
           if (n) refreshNodeAudio(n);
         });


### PR DESCRIPTION
## Summary
- Safely update each linked node's parameter object to mirror group changes without triggering recursive proxy updates.

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a978cd6b74832c8c70211bfce7e466