### PR TITLE
Prevent linking parameters across different node types

### DIFF
--- a/main.js
+++ b/main.js
@@ -906,16 +906,21 @@ function refreshNodeAudio(node) {
   updateNodeAudioParams(node);
 }
 
-function makeParameterGroup() {
-  const selectedNodes = Array.from(selectedElements)
-    .filter((el) => el.type === "node")
-    .map((el) => findNodeById(el.id))
-    .filter((n) => n && isPlayableNode(n));
+  function makeParameterGroup() {
+    const selectedNodes = Array.from(selectedElements)
+      .filter((el) => el.type === "node")
+      .map((el) => findNodeById(el.id))
+      .filter((n) => n && isPlayableNode(n) && n.audioParams);
 
-  if (selectedNodes.length < 2) {
-    alert("Select at least two nodes to link.");
-    return;
-  }
+    if (selectedNodes.length < 2) {
+      alert("Select at least two compatible nodes to link.");
+      return;
+    }
+    const firstNodeType = selectedNodes[0].type;
+    if (!selectedNodes.every((n) => n.type === firstNodeType)) {
+      alert("Select nodes of the same type to link.");
+      return;
+    }
   paramGroups.forEach((g) => {
     selectedNodes.forEach((n) => g.nodeIds.delete(n.id));
   });


### PR DESCRIPTION
## Summary
- ensure parameter linking only occurs for nodes of the same type with audio parameters
## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9980c71a0832c9fde32eef831b484