### PR TITLE
feat: add osc type control for drone voices

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,4 @@ The file `polyChordExample.js` demonstrates using `Tone.PolySynth` to trigger ch
 - Arvo Drone oscillators now use resonant bandpass filtering for a more string-like timbre.
 - Arvo Drone now features a sitar-style resonator and short comb delay for enhanced string resonance.
 - Arvo Drone gains extra oscillators and a single "Motion" control for evolving textures.
+- Drone voices now include an `oscType` parameter allowing selection of sine, square, triangle or sawtooth waveforms (plus the original string wave).


### PR DESCRIPTION
## Summary
- allow FM drone voice to choose oscillator waveform and expose selector in UI
- add waveform selector and parameter to Arvo drone voices
- document new `oscType` parameter in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa2aba9910832c9450339ffacef185