### PR TITLE
Add swarm visual style for FM drone

### DIFF
--- a/main.js
+++ b/main.js
@@ -12812,16 +12812,60 @@ function drawNode(node) {
     ctx.stroke();
     ctx.restore();
   } else if (node.type === FM_DRONE_TYPE) {
-    ctx.save();
-    ctx.translate(node.x, node.y);
-    ctx.fillStyle = fillColor;
-    ctx.strokeStyle = borderColor;
-    ctx.lineWidth = Math.max(0.5 / viewScale, baseLineWidth / viewScale);
-    ctx.beginPath();
-    ctx.arc(0, 0, r, 0, Math.PI * 2);
-    ctx.fill();
-    ctx.stroke();
-    ctx.restore();
+    const visualStyle = node.audioParams?.visualStyle;
+    if (visualStyle === "fm_drone_swarm") {
+      const particleCount = 20;
+      const size = r * 0.15;
+      const swarmFill = hslToRgba(290, 70, 70, 0.8);
+      const swarmBorder = hslToRgba(290, 70, 50, 0.9);
+      if (!node.swarmParticles) {
+        node.swarmParticles = Array.from({ length: particleCount }, () => ({
+          angle: Math.random() * Math.PI * 2,
+          radius: r * (0.3 + Math.random() * 0.7),
+          speed: 0.01 + Math.random() * 0.02,
+        }));
+      }
+      node.swarmParticles.forEach((p) => {
+        const rate = node.audioParams?.lfoRate || 0.5;
+        p.angle += p.speed * (0.5 + rate);
+        const px = node.x + Math.cos(p.angle) * p.radius;
+        const py = node.y + Math.sin(p.angle) * p.radius;
+        ctx.beginPath();
+        ctx.arc(px, py, size, 0, Math.PI * 2);
+        ctx.fillStyle = swarmFill;
+        ctx.fill();
+      });
+      nodes.forEach((other) => {
+        if (
+          other !== node &&
+          other.type === FM_DRONE_TYPE &&
+          other.audioParams?.visualStyle === "fm_drone_swarm"
+        ) {
+          const dx = other.x - node.x;
+          const dy = other.y - node.y;
+          const dist = Math.hypot(dx, dy);
+          if (dist < r * 4) {
+            ctx.strokeStyle = swarmBorder;
+            ctx.lineWidth = Math.max(0.5 / viewScale, 1 / viewScale);
+            ctx.beginPath();
+            ctx.moveTo(node.x, node.y);
+            ctx.lineTo(other.x, other.y);
+            ctx.stroke();
+          }
+        }
+      });
+    } else {
+      ctx.save();
+      ctx.translate(node.x, node.y);
+      ctx.fillStyle = fillColor;
+      ctx.strokeStyle = borderColor;
+      ctx.lineWidth = Math.max(0.5 / viewScale, baseLineWidth / viewScale);
+      ctx.beginPath();
+      ctx.arc(0, 0, r, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+      ctx.restore();
+    }
   } else if (isPulsarType(node.type)) {
     const outerR = r;
     const innerR = outerR * 0.4;

--- a/orbs/fm-drone-orb.js
+++ b/orbs/fm-drone-orb.js
@@ -24,7 +24,7 @@ export const DEFAULT_FM_DRONE_PARAMS = {
   lfoDepth: 200,
   reverbSend: 0.2,
   delaySend: 0.2,
-  visualStyle: 'fm_drone_default',
+  visualStyle: 'fm_drone_swarm',
   ignoreGlobalSync: false,
 };
 


### PR DESCRIPTION
## Summary
- render FM drone using particle swarm animation
- connect nearby FM drone swarms for interactive visuals

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68aa2d151388832c9f3b6f5362c67ec0