### PR TITLE
Allow note selection for flux drone

### DIFF
--- a/main.js
+++ b/main.js
@@ -22618,6 +22618,35 @@ function addNode(x, y, type, subtype = null, optionalDimensions = null) {
     }
     visualStyle = "alien_orb_default";
     nodeSubtypeForAudioParams = null;
+  } else if (type === ALIEN_DRONE_TYPE) {
+    initialScaleIndex =
+      noteIndexToAdd !== -1 && noteIndexToAdd !== null
+        ? noteIndexToAdd
+        : Math.floor(Math.random() * currentScale.notes.length * 3)
+          - currentScale.notes.length;
+    initialScaleIndex = Math.max(
+      MIN_SCALE_INDEX,
+      Math.min(MAX_SCALE_INDEX, initialScaleIndex),
+    );
+    initialPitch = getFrequency(
+      currentScale,
+      initialScaleIndex,
+      0,
+      currentRootNote,
+      globalTransposeOffset,
+    );
+    if (isNaN(initialPitch) || initialPitch <= 0) {
+      initialScaleIndex = 0;
+      initialPitch = getFrequency(
+        currentScale,
+        0,
+        0,
+        currentRootNote,
+        globalTransposeOffset,
+      );
+    }
+    visualStyle = "alien_drone_default";
+    nodeSubtypeForAudioParams = null;
   } else if (type === RESONAUTER_TYPE) {
     initialScaleIndex =
       noteIndexToAdd !== -1 && noteIndexToAdd !== null
@@ -23774,7 +23803,12 @@ function setupAddTool(
       if (sideToolbar) sideToolbar.classList.remove("narrow");
       sideToolbarContent.innerHTML = "";
       createHexNoteSelectorDOM(sideToolbarContent);
-    } else if (type === RESONAUTER_TYPE || type === ARVO_DRONE_TYPE || type === FM_DRONE_TYPE) {
+    } else if (
+      type === RESONAUTER_TYPE ||
+      type === ARVO_DRONE_TYPE ||
+      type === FM_DRONE_TYPE ||
+      type === ALIEN_DRONE_TYPE
+    ) {
       if (sideToolbar) sideToolbar.classList.remove("hidden");
       if (sideToolbar) sideToolbar.classList.remove("narrow");
       sideToolbarContent.innerHTML = "";


### PR DESCRIPTION
## Summary
- allow alien/flux drones to pick notes with random default
- show note picker when adding a flux drone so pitch colors match other nodes

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa939257a0832c9e6aae04b84ffcc6