### PR TITLE
Enable note selection for FM drone

### DIFF
--- a/main.js
+++ b/main.js
@@ -11994,8 +11994,8 @@ function drawNode(node) {
         border: hslToRgba(0, 0, 10, 0.9),
       },
       fm_drone_swarm: {
-        fill: hslToRgba(290, 70, 70, 0.8),
-        border: hslToRgba(290, 70, 50, 0.9),
+        fill: fillColor,
+        border: borderColor,
       },
       arvo_drone_default: {
         fill: hslToRgba(200, 40, 60, baseAlpha),
@@ -12909,11 +12909,9 @@ function drawNode(node) {
   } else if (node.type === FM_DRONE_TYPE) {
     const visualStyle = node.audioParams?.visualStyle;
     if (visualStyle === "fm_drone_swarm") {
-      const swarmFill = hslToRgba(290, 70, 70, 0.8);
-      const swarmBorder = hslToRgba(290, 70, 50, 0.9);
       updateAndDrawFmDroneSwarm(node, nodes, ctx, r, {
-        fill: swarmFill,
-        border: swarmBorder,
+        fill: fillColor,
+        border: borderColor,
       });
     } else {
       ctx.save();
@@ -22963,6 +22961,7 @@ function addNode(x, y, type, subtype = null, optionalDimensions = null) {
   } else if (type === FM_DRONE_TYPE) {
     newNode.audioParams = Object.assign({}, DEFAULT_FM_DRONE_PARAMS, {
         pitch: initialPitch,
+        baseFreq: initialPitch,
         scaleIndex: initialScaleIndex,
     });
   } else if (type === RESONAUTER_TYPE) {

--- a/orbs/fm-drone-orb.js
+++ b/orbs/fm-drone-orb.js
@@ -15,6 +15,8 @@ async function getNexus() {
 }
 
 export const DEFAULT_FM_DRONE_PARAMS = {
+  pitch: 110,
+  scaleIndex: 0,
   baseFreq: 110,
   harmonicity: 1.5,
   modulationIndex: 10,
@@ -31,13 +33,14 @@ export const DEFAULT_FM_DRONE_PARAMS = {
 export function createFmDroneAudioNodes(node) {
   const p = node.audioParams;
   const ctx = globalThis.audioContext;
+  const baseFreq = p.pitch || p.baseFreq || 110;
   const carrier = ctx.createOscillator();
   carrier.type = p.oscType || 'sine';
-  carrier.frequency.value = p.baseFreq || 110;
+  carrier.frequency.value = baseFreq;
 
   const modOsc = ctx.createOscillator();
   modOsc.type = 'sine';
-  modOsc.frequency.value = (p.baseFreq || 110) * (p.harmonicity || 1.5);
+  modOsc.frequency.value = baseFreq * (p.harmonicity || 1.5);
 
   const modGain = ctx.createGain();
   modGain.gain.value = p.modulationIndex || 10;
@@ -104,8 +107,9 @@ export function updateFmDroneParams(audioNodes) {
   if (!p) return;
   const ctx = globalThis.audioContext;
   const now = ctx.currentTime;
-  audioNodes.carrier.frequency.setTargetAtTime(p.baseFreq ?? 110, now, 0.1);
-  audioNodes.modOsc.frequency.setTargetAtTime((p.baseFreq ?? 110) * (p.harmonicity ?? 1.5), now, 0.1);
+  const baseFreq = p.pitch ?? p.baseFreq ?? 110;
+  audioNodes.carrier.frequency.setTargetAtTime(baseFreq, now, 0.1);
+  audioNodes.modOsc.frequency.setTargetAtTime(baseFreq * (p.harmonicity ?? 1.5), now, 0.1);
   audioNodes.modGain.gain.setTargetAtTime(p.modulationIndex ?? 10, now, 0.1);
   audioNodes.lfo.frequency.setTargetAtTime(p.lfoRate ?? 0.05, now, 0.1);
   audioNodes.lfoGain.gain.setTargetAtTime(p.lfoDepth ?? 200, now, 0.1);


### PR DESCRIPTION
## Summary
- Allow FM Drone to use selected notes by extending its default parameters with pitch and scale index
- Update FM drone audio node creation to derive frequencies from the chosen pitch
- Store selected note frequency when creating FM drone nodes
- Color FM Drone swarm visuals according to the selected note

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68aaa184a038832c9d75d6c1d5a699be