### PR TITLE
feat: add FM-based shape morphing utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Canvas Orbs to the scene.
 Reusable helper functions live in separate modules. `audioUtils.js` handles note
 and scale calculations. `mathUtils.js` provides general math helpers such as
 `clamp()`, `lerp()` and random number generators.
+`fmShapeMorph.js` offers simple FM-based shape morphing utilities for visual experiments.
 
 ## Autosave
 

--- a/test/fmShapeMorph.test.js
+++ b/test/fmShapeMorph.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { morphShape, fmMorphAmount } from '../utils/fmShapeMorph.js';
+
+describe('morphShape', () => {
+  it('interpolates between two shapes', () => {
+    const a = [{ x: 0, y: 0 }, { x: 2, y: 0 }];
+    const b = [{ x: 2, y: 2 }, { x: 4, y: 2 }];
+    const result = morphShape(a, b, 0.5);
+    expect(result[0]).toEqual({ x: 1, y: 1 });
+    expect(result[1]).toEqual({ x: 3, y: 1 });
+  });
+
+  it('clamps amount to 0..1', () => {
+    const a = [{ x: 0, y: 0 }];
+    const b = [{ x: 2, y: 2 }];
+    const result = morphShape(a, b, 2);
+    expect(result[0]).toEqual({ x: 2, y: 2 });
+  });
+});
+
+describe('fmMorphAmount', () => {
+  it('returns values between 0 and 1', () => {
+    const values = Array.from({ length: 5 }, (_, i) =>
+      fmMorphAmount(2, 1, 1, i * 0.1)
+    );
+    values.forEach(v => {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    });
+  });
+});

--- a/utils/fmShapeMorph.js
+++ b/utils/fmShapeMorph.js
@@ -1,0 +1,39 @@
+import { lerp } from '../mathUtils.js';
+
+/**
+ * Morph between two shapes based on a normalized amount.
+ * @param {Array<{x:number,y:number}>} baseShape
+ * @param {Array<{x:number,y:number}>} targetShape
+ * @param {number} amount - value between 0 and 1
+ * @returns {Array<{x:number,y:number}>}
+ */
+export function morphShape(baseShape, targetShape, amount) {
+  if (!Array.isArray(baseShape) || !Array.isArray(targetShape)) {
+    throw new TypeError('Shapes must be arrays');
+  }
+  if (baseShape.length !== targetShape.length) {
+    throw new Error('Shapes must have the same number of points');
+  }
+  const t = Math.max(0, Math.min(1, amount));
+  return baseShape.map((p, i) => ({
+    x: lerp(p.x, targetShape[i].x, t),
+    y: lerp(p.y, targetShape[i].y, t),
+  }));
+}
+
+/**
+ * Simple FM oscillator value mapped to 0-1 for shape morphing.
+ * @param {number} carrierFreq
+ * @param {number} modFreq
+ * @param {number} modulationIndex
+ * @param {number} time - in seconds
+ * @returns {number} value between 0 and 1
+ */
+export function fmMorphAmount(carrierFreq, modFreq, modulationIndex, time) {
+  const mod = Math.sin(2 * Math.PI * modFreq * time) * modulationIndex;
+  const instantaneousFreq = carrierFreq + mod;
+  const sample = Math.sin(2 * Math.PI * instantaneousFreq * time);
+  return (sample + 1) / 2; // map from [-1,1] to [0,1]
+}
+
+export default { morphShape, fmMorphAmount };


### PR DESCRIPTION
## Summary
- add `fmShapeMorph.js` for FM oscillator-driven shape blending
- document new utility in README
- cover shape morphing functions with unit tests

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68aad469ffbc832c860e40b6de797f2d