### PR TITLE
Use vector morphing for FM drone swarm shapes

### DIFF
--- a/test/fmShapeMorph.test.js
+++ b/test/fmShapeMorph.test.js
@@ -16,6 +16,22 @@ describe('morphShape', () => {
     const result = morphShape(a, b, 2);
     expect(result[0]).toEqual({ x: 2, y: 2 });
   });
+
+  it('handles shapes with different point counts', () => {
+    const tri = [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 1, y: 2 },
+    ];
+    const square = [
+      { x: 0, y: 0 },
+      { x: 2, y: 0 },
+      { x: 2, y: 2 },
+      { x: 0, y: 2 },
+    ];
+    const result = morphShape(tri, square, 0.5);
+    expect(result).toHaveLength(4);
+  });
 });
 
 describe('fmMorphAmount', () => {


### PR DESCRIPTION
## Summary
- Rework shape morphing utilities to resample point counts for smooth vector transitions
- Draw FM drone swarm using morphing polygons instead of fading between static shapes
- Test morphing with mismatched point counts

## Testing
- `npm ci`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68aadc7d0220832c910b9ee445dcb443