### PR TITLE
fix: limit fm drone auto drift to single swarm

### DIFF
--- a/orbs/analog-orb-ui.js
+++ b/orbs/analog-orb-ui.js
@@ -144,6 +144,7 @@ export function hideAnalogOrbMenu() {
 
 export function hideTonePanel() {
   if (tonePanel) tonePanel.classList.add('hidden');
+  import('./fm-drone-orb.js').then((m) => m.hideFmDroneOrbMenu?.());
 }
 
 export function positionTonePanel(node) {

--- a/orbs/fm-drone-orb.js
+++ b/orbs/fm-drone-orb.js
@@ -1,6 +1,6 @@
 export const FM_DRONE_TYPE = 'fm_drone';
 import { tonePanelContent } from '../utils/domElements.js';
-import { updateNodeAudioParams } from '../main.js';
+import { updateNodeAudioParams, nodes } from '../main.js';
 import { showTonePanel, hideAnalogOrbMenu } from './analog-orb-ui.js';
 
 let NexusPromise = typeof window !== 'undefined' ? import('nexusui') : null;
@@ -165,6 +165,11 @@ export function stopFmDroneAudioNodes(audioNodes) {
     audioNodes.modOsc?.stop();
     audioNodes.lfo?.stop();
   } catch (e) {}
+  const node = audioNodes.nodeRef;
+  if (node?.autoDriftInterval) {
+    clearInterval(node.autoDriftInterval);
+    node.autoDriftInterval = null;
+  }
   Object.values(audioNodes).forEach(n => {
     try { n.disconnect(); } catch (e) {}
   });
@@ -335,10 +340,12 @@ export async function showFmDroneOrbMenu(node) {
   const btn = document.createElement('button');
   btn.textContent = 'Auto Drift';
   container.appendChild(btn);
-  let autoInterval = null;
+  let autoInterval = node.autoDriftInterval || null;
+  if (autoInterval) btn.classList.add('active');
   btn.addEventListener('click', () => {
     if (autoInterval) {
       clearInterval(autoInterval);
+      node.autoDriftInterval = null;
       autoInterval = null;
       btn.classList.remove('active');
     } else {
@@ -350,13 +357,24 @@ export async function showFmDroneOrbMenu(node) {
           setPadPosition(p, x, y);
         });
       }, 2000);
+      node.autoDriftInterval = autoInterval;
     }
   });
 }
 
 export function hideFmDroneOrbMenu() {
   const existing = document.getElementById('fm-drone-container');
-  if (existing) existing.remove();
+  if (existing) {
+    const nodeId = existing.dataset.nodeId;
+    if (nodeId) {
+      const n = nodes.find((x) => String(x.id) === nodeId);
+      if (n && n.autoDriftInterval) {
+        clearInterval(n.autoDriftInterval);
+        n.autoDriftInterval = null;
+      }
+    }
+    existing.remove();
+  }
   if (tonePanelContent) tonePanelContent.innerHTML = '';
   hideAnalogOrbMenu();
 }


### PR DESCRIPTION
## Summary
- store Auto Drift interval on each FM drone node and only create one interval
- clear Auto Drift interval when the tone panel, FM drone menu, or audio nodes close

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68aadecd4168832ca5fea9571833476f