### PR TITLE
Animate FM drone pads with modulation knobs

### DIFF
--- a/test/fmDroneSwarmReset.test.js
+++ b/test/fmDroneSwarmReset.test.js
@@ -7,21 +7,30 @@ vi.mock('nexusui', () => ({
       constructor() {}
       on() {}
       set() {}
+      colorize() {}
+    },
+    Dial: class {
+      constructor() { this.value = 0; }
+      on() {}
+      colorize() {}
     },
   },
 }));
 
 vi.mock('../utils/domElements.js', async () => {
   const actual = await vi.importActual('../utils/domElements.js');
+  const t = document.createElement('div');
+  document.body.appendChild(t);
   return {
     ...actual,
-    tonePanelContent: document.createElement('div'),
+    tonePanelContent: t,
   };
 });
 
+const nodesMock = [];
 vi.mock('../main.js', () => ({
   updateNodeAudioParams: vi.fn(),
-  nodes: [],
+  nodes: nodesMock,
 }));
 
 vi.mock('../orbs/analog-orb-ui.js', () => ({
@@ -29,11 +38,18 @@ vi.mock('../orbs/analog-orb-ui.js', () => ({
   hideAnalogOrbMenu: vi.fn(),
 }));
 
+vi.stubGlobal('requestAnimationFrame', () => 1);
+vi.stubGlobal('cancelAnimationFrame', vi.fn());
+
 describe('FM Drone swarm reset', () => {
-  it('clears existing swarm particles when menu opens', async () => {
-    const { showFmDroneOrbMenu, FM_DRONE_TYPE } = await import('../orbs/fm-drone-orb.js');
+  it('clears swarm particles and runs auto drift', async () => {
+    const { showFmDroneOrbMenu, hideFmDroneOrbMenu, FM_DRONE_TYPE } = await import('../orbs/fm-drone-orb.js');
     const node = { id: 1, type: FM_DRONE_TYPE, audioParams: {}, swarmParticles: [{}, {}] };
+    nodesMock.push(node);
     await showFmDroneOrbMenu(node);
     expect(node.swarmParticles).toEqual([]);
+    expect(node.autoDriftInterval).toBe(1);
+    hideFmDroneOrbMenu();
+    expect(node.autoDriftInterval).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- start continuous auto-drift for FM drone pads driven by side dials
- update pad positions and audio params live so swarm visuals follow
- ensure animation frames are cancelled when nodes stop and add tests for reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaf2b02910832c8e1a7c1fdcff923c