### PR TITLE
Add per-operator LFO controls to FM synth orb

### DIFF
--- a/main.js
+++ b/main.js
@@ -3835,6 +3835,9 @@ export function updateNodeAudioParams(node) {
     modulatorGain2,
     modulatorOsc3,
     modulatorGain3,
+    modulatorLfo1,
+    modulatorLfo2,
+    modulatorLfo3,
     carrierEnv,
     modulatorEnv1,
     modulatorEnv2,
@@ -3931,6 +3934,39 @@ export function updateNodeAudioParams(node) {
       if (modulatorGain3 && params.modulator3DepthScale !== undefined) {
         modulatorGain3.gain.setTargetAtTime(
           params.modulator3DepthScale * 10,
+          now,
+          generalUpdateTimeConstant,
+        );
+      }
+      if (modulatorLfo1) {
+        const base = (params.modulatorDepthScale ?? 0) * 10;
+        const depth = (params.modulatorLfoDepth ?? 0) * 10;
+        modulatorLfo1.min = base - depth;
+        modulatorLfo1.max = base + depth;
+        modulatorLfo1.frequency.setTargetAtTime(
+          params.modulatorLfoRate ?? 0,
+          now,
+          generalUpdateTimeConstant,
+        );
+      }
+      if (modulatorLfo2) {
+        const base = (params.modulator2DepthScale ?? 0) * 10;
+        const depth = (params.modulator2LfoDepth ?? 0) * 10;
+        modulatorLfo2.min = base - depth;
+        modulatorLfo2.max = base + depth;
+        modulatorLfo2.frequency.setTargetAtTime(
+          params.modulator2LfoRate ?? 0,
+          now,
+          generalUpdateTimeConstant,
+        );
+      }
+      if (modulatorLfo3) {
+        const base = (params.modulator3DepthScale ?? 0) * 10;
+        const depth = (params.modulator3LfoDepth ?? 0) * 10;
+        modulatorLfo3.min = base - depth;
+        modulatorLfo3.max = base + depth;
+        modulatorLfo3.frequency.setTargetAtTime(
+          params.modulator3LfoRate ?? 0,
           now,
           generalUpdateTimeConstant,
         );

--- a/orbs/tone-fm-synth-orb.js
+++ b/orbs/tone-fm-synth-orb.js
@@ -6,12 +6,18 @@ export const DEFAULT_TONE_FM_SYNTH_PARAMS = {
   modulatorWaveform: 'sine',
   modulatorRatio: 1,
   modulatorDepthScale: 0,
+  modulatorLfoRate: 0,
+  modulatorLfoDepth: 0,
   modulator2Waveform: 'sine',
   modulator2Ratio: 1,
   modulator2DepthScale: 0,
+  modulator2LfoRate: 0,
+  modulator2LfoDepth: 0,
   modulator3Waveform: 'sine',
   modulator3Ratio: 1,
   modulator3DepthScale: 0,
+  modulator3LfoRate: 0,
+  modulator3LfoDepth: 0,
   algorithm: 0,
   carrierEnvAttack: 0.01,
   carrierEnvDecay: 0.3,
@@ -129,11 +135,20 @@ export function createToneFmSynthOrb(node) {
     const envGain = new Tone.Gain(0);
     env.connect(envGain.gain);
     osc.connect(envGain);
-    const modGain = new Tone.Gain((p[`${prefix}DepthScale`] ?? 0) * 10);
+    const depthBase = (p[`${prefix}DepthScale`] ?? 0) * 10;
+    const modGain = new Tone.Gain(depthBase);
     envGain.connect(modGain);
+    const lfo = new Tone.LFO({
+      frequency: p[`${prefix}LfoRate`] ?? 0,
+      min: depthBase - (p[`${prefix}LfoDepth`] ?? 0) * 10,
+      max: depthBase + (p[`${prefix}LfoDepth`] ?? 0) * 10,
+      phase: 90,
+    });
+    lfo.connect(modGain.gain);
+    lfo.start();
     const outGain = new Tone.Gain(1);
     envGain.connect(outGain);
-    return { osc, env, modGain, outGain };
+    return { osc, env, modGain, outGain, lfo };
   }
 
   const op1 = createOperator('carrier', 'carrier');
@@ -229,12 +244,15 @@ export function createToneFmSynthOrb(node) {
     modulatorOsc1: op2.osc,
     modulatorGain1: op2.modGain,
     modulatorEnv1: op2.env,
+    modulatorLfo1: op2.lfo,
     modulatorOsc2: op3.osc,
     modulatorGain2: op3.modGain,
     modulatorEnv2: op3.env,
+    modulatorLfo2: op3.lfo,
     modulatorOsc3: op4.osc,
     modulatorGain3: op4.modGain,
     modulatorEnv3: op4.env,
+    modulatorLfo3: op4.lfo,
     lowPassFilter: filter,
     gainNode,
     reverbSendGain,

--- a/orbs/tone-fm-synth-ui.js
+++ b/orbs/tone-fm-synth-ui.js
@@ -228,6 +228,8 @@ export async function showToneFmSynthMenu(node) {
     { suffix: 'EnvRelease', short: 'R', min: 0, max: 4, step: 0.01, format: v => v.toFixed(2) },
     { suffix: 'Ratio', short: 'Rat', min: 0.1, max: 10, step: 0.1, format: v => v.toFixed(1) },
     { suffix: 'DepthScale', short: 'Dep', min: 0, max: 10, step: 0.1, format: v => (v * 10).toFixed(1) },
+    { suffix: 'LfoRate', short: 'LR', min: 0, max: 10, step: 0.01, format: v => v.toFixed(2) },
+    { suffix: 'LfoDepth', short: 'LD', min: 0, max: 10, step: 0.1, format: v => (v * 10).toFixed(1) },
     { suffix: 'Detune', short: 'Det', min: -1200, max: 1200, step: 1, format: v => v.toFixed(0) },
     { suffix: 'Waveform', short: 'W', type: 'select', options: ['sine', 'square', 'triangle', 'sawtooth'] },
   ];


### PR DESCRIPTION
## Summary
- allow each FM operator's modulation depth to be animated by its own LFO
- expose LFO rate and depth knobs in the FM synth UI
- keep audio nodes in sync when LFO settings change

## Testing
- `CI=1 npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aafc00d27c832cbae9a649a16122cc