### PR TITLE
Fix timeline track width calculation

### DIFF
--- a/style.css
+++ b/style.css
@@ -122,7 +122,7 @@
   --meter-fill-mid: rgba(0,191,255,0.9);
   --meter-fill-end: rgba(138,43,226,0.9);
   --meter-gain-indicator-color: rgba(255, 255, 255, 0.7);
-  --timeline-pixels-per-second: 100;
+  --timeline-pixels-per-second: 100px;
   --timeline-loop-bar-height: 20px;
   --timeline-track-header-height: 32px;
 }


### PR DESCRIPTION
## Summary
- add CSS units to `--timeline-pixels-per-second` so timeline tracks get proper width

## Testing
- `npm ci`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ab00259ecc832cbaf43c662685da81