### PR TITLE
Fix radio sampler layout after Nexus integration

### DIFF
--- a/style.css
+++ b/style.css
@@ -1478,47 +1478,69 @@ margin-top: 6px;
 .performance-block { flex: 1; margin: 0 10px; padding-bottom: 10px; border-right: 1px solid var(--button-bg); }
 .performance-block:last-child { border-right: none; }
 #radioSamplerPanel h3 { margin-top: 0; text-align: center; font-size: 1em; }
-#radioSamplerGrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 5px; margin: 10px 0; }
+#radioSamplerGrid {
+  display: grid !important;
+  grid-template-columns: repeat(3, 1fr) !important;
+  gap: 5px !important;
+  margin: 10px 0 !important;
+}
 #radioSamplerGrid .radio-pad {
-  width: 100%;
-  background-color: #444;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  position: relative;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  cursor: pointer;
-  padding-bottom: 22px;
+  width: 100% !important;
+  background-color: #444 !important;
+  color: #fff !important;
+  border: none !important;
+  border-radius: 4px !important;
+  position: relative !important;
+  display: flex !important;
+  justify-content: center !important;
+  align-items: center !important;
+  cursor: pointer !important;
+  padding-bottom: 22px !important;
 }
-#radioSamplerGrid .radio-pad.playing { background-color: var(--button-active, #8860b0); box-shadow: 0 0 6px var(--button-active, #8860b0); }
-#radioSamplerGrid canvas { width: 100%; height: 40px; display: block; }
+#radioSamplerGrid .radio-pad.playing {
+  background-color: var(--button-active, #8860b0) !important;
+  box-shadow: 0 0 6px var(--button-active, #8860b0) !important;
+}
+#radioSamplerGrid canvas {
+  width: 100% !important;
+  height: 40px !important;
+  display: block !important;
+}
 #radioSamplerGrid .pad-controls {
-  position: absolute;
-  bottom: 2px;
-  left: 0;
-  width: 100%;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 2px;
-  box-sizing: border-box;
+  position: absolute !important;
+  bottom: 2px !important;
+  left: 0 !important;
+  width: 100% !important;
+  display: flex !important;
+  justify-content: space-between !important;
+  align-items: center !important;
+  padding: 2px !important;
+  box-sizing: border-box !important;
 }
-#radioSamplerGrid .pad-rec-btn { font-size: 0.7em; padding: 2px 4px; background-color: #800; color: #fff; border: none; border-radius: 3px; cursor: pointer; }
-#radioSamplerGrid .pad-rec-btn.recording { background-color: #f00; }
+#radioSamplerGrid .pad-rec-btn {
+  font-size: 0.7em !important;
+  padding: 2px 4px !important;
+  background-color: #800 !important;
+  color: #fff !important;
+  border: none !important;
+  border-radius: 3px !important;
+  cursor: pointer !important;
+}
+#radioSamplerGrid .pad-rec-btn.recording {
+  background-color: #f00 !important;
+}
 #radioSamplerGrid .pad-step-toggle {
-  font-size: 0.7em;
-  padding: 2px 4px;
-  background-color: #222;
-  color: #fff;
-  border: 1px solid #555;
-  border-radius: 3px;
-  cursor: pointer;
+  font-size: 0.7em !important;
+  padding: 2px 4px !important;
+  background-color: #222 !important;
+  color: #fff !important;
+  border: 1px solid #555 !important;
+  border-radius: 3px !important;
+  cursor: pointer !important;
 }
 #radioSamplerGrid .pad-step-toggle.on {
-  background-color: #6c6;
-  border-color: #8f8;
+  background-color: #6c6 !important;
+  border-color: #8f8 !important;
 }
 #radioPadEditor { margin-top: 8px; }
 #radioWaveformCanvas { width: 100%; height: 60px; background-color: #222; border: 1px solid #111; border-radius: 3px; }


### PR DESCRIPTION
## Summary
- Force radio sampler pad grid styles to override Nexus defaults
- Ensure pad controls and canvas display correctly

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab0fa80530832c87d74a31b33741c8