### PR TITLE
Add Simple instrument and rename Tone Synth to Analog Synth

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
         <div id="toolbar-column-right">
             <p class="toolbar-column-title">Sound & Tools</p>
             <div id="toolbar-sound-generators">
-                <button id="instrumentsMenuBtn" title="Open Instruments Menu">🎼</button>
+                <button id="instrumentsMenuBtn" data-node-type="sound" title="Open Instruments Menu">🎼</button>
                 <button id="connectionsMenuBtn" title="Open Connections Menu">🔗</button>
                 <button id="toolsMenuBtn" title="Open Tools Menu">🛠️</button>
                 <button id="mistMenuBtn" title="Open Mist Menu">🌁</button>
@@ -409,7 +409,7 @@
 
     <div id="tone-panel" class="panel prorb-panel hidden">
         <div id="tone-panel-header">
-            <h3>Tone Synth Settings</h3>
+            <h3>Analog Synth Settings</h3>
             <button id="tone-panel-close-btn" class="close-panel-button">&times;</button>
         </div>
         <div id="tone-panel-content"></div>

--- a/main.js
+++ b/main.js
@@ -20394,8 +20394,18 @@ function populateInstrumentMenu() {
 
   const instruments = [
     {
+      icon: "🎵",
+      label: "Simple",
+      nodeType: "sound",
+      handler: () => {
+        soundEngineToAdd = null;
+        setupAddTool(null, "sound");
+      },
+    },
+    {
       icon: "🔔",
       label: "FM Synth",
+      nodeType: "sound",
       handler: () => {
         soundEngineToAdd = "tonefm";
         setupAddTool(null, "sound", true, "fmSynths", "FM Synths");
@@ -20403,15 +20413,17 @@ function populateInstrumentMenu() {
     },
     {
       icon: "🎶",
-      label: "Tone Synth",
+      label: "Analog Synth",
+      nodeType: "sound",
       handler: () => {
         soundEngineToAdd = "tone";
-        setupAddTool(null, "sound", true, "analogWaveforms", "Tone Synths");
+        setupAddTool(null, "sound", true, "analogWaveforms", "Analog Synths");
       },
     },
     {
       icon: "🛰️",
       label: "Sampler",
+      nodeType: "sound",
       handler: () => {
         soundEngineToAdd = null;
         setupAddTool(null, "sound", true, "samplers", "Samplers");
@@ -20461,20 +20473,23 @@ function populateInstrumentMenu() {
   instruments.forEach((inst) => {
     const btn = document.createElement("button");
     btn.classList.add("type-button");
-    btn.innerHTML = `<span class="type-icon">${inst.icon}</span> <span>${inst.label}</span>`;
+    btn.innerHTML = `<span class=\"type-icon\">${inst.icon}</span> <span>${inst.label}</span>`;
     btn.addEventListener("click", () => {
       inst.handler();
       if (
         helpWizard &&
         !helpWizard.classList.contains("hidden") &&
         currentHelpStep === 3 &&
-        inst.label === "Tone Synth"
+        inst.label === "Analog Synth"
       ) {
         nextHelpStep();
       }
     });
-    if (inst.label === "Tone Synth") {
-      toneSynthBtn = btn;
+    if (inst.nodeType) {
+      btn.dataset.nodeType = inst.nodeType;
+    }
+    if (inst.label === "Analog Synth") {
+      analogSynthBtn = btn;
       helpSteps[3].target = btn;
     }
     groupDiv.appendChild(btn);
@@ -21662,7 +21677,7 @@ function toggleHelpPopup() {
   }
 }
 
-let toneSynthBtn = null;
+let analogSynthBtn = null;
 let squareWaveBtn = null;
 const helpSteps = [
   {
@@ -21678,7 +21693,7 @@ const helpSteps = [
     target: instrumentsMenuBtn,
   },
   {
-    text: "Choose Tone Synth",
+    text: "Choose Analog Synth",
     target: null,
   },
   {
@@ -23872,7 +23887,7 @@ if (addAnalogSynthBtn) {
       "sound",
       true,
       "analogWaveforms",
-      "Tone Synths",
+      "Analog Synths",
     );
   });
 }


### PR DESCRIPTION
## Summary
- Add "Simple" sound option at the top of the Instruments menu and tag Instruments button with `data-node-type="sound"`
- Rename "Tone Synth" to "Analog Synth" across UI and help text

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab225ddf04832ca2f06a7ec708d243