### PR TITLE
Fix sampler audio path resolution

### DIFF
--- a/samplers.js
+++ b/samplers.js
@@ -1,6 +1,9 @@
 function resolveSamplePath(path) {
     if (typeof window !== "undefined" && window.location.protocol !== "file:") {
-        return path;
+        const base =
+            window.location.origin +
+            window.location.pathname.replace(/\/[^\/]*$/, "/");
+        return new URL(path, base).href;
     }
     return new URL(`./public/${path}`, import.meta.url).href;
 }


### PR DESCRIPTION
## Summary
- construct browser sampler URLs relative to current path for robust audio loading

## Testing
- `npm ci`
- `npm test` *(fails: meteor.test.js timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5c0f6b98832c9fc072a426d14b41