### PR TITLE
Ensure sampler orbs trigger reliably

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ import { createAnalogOrb, DEFAULT_ANALOG_ORB_PARAMS } from './orbs/analog-orb.js
 import { showAnalogOrbMenu, hideAnalogOrbMenu, hideTonePanel } from './orbs/analog-orb-ui.js';
 import { showToneFmSynthMenu } from './orbs/tone-fm-synth-ui.js';
 import * as Tone from 'tone';
+import { playWithToneSampler } from './samplerPlayer.js';
 import { sanitizeWaveformType } from './utils/oscillatorUtils.js';
 import { morphShape } from './utils/fmShapeMorph.js';
 import { DEFAULT_RESONAUTER_PARAMS, resonauterGranParams, createResonauterOrbAudioNodes, playResonauterSound } from './orbs/resonauter-orb.js';
@@ -8834,34 +8835,7 @@ function getReversedBuffer(definition) {
   return reversed;
 }
 
-function playWithToneSampler(
-  buffer,
-  baseFreq,
-  freq,
-  startTime,
-  attack,
-  release,
-  velocity,
-  destination,
-) {
-  const rootNote = Tone.Frequency(baseFreq).toNote();
-  const note = Tone.Frequency(freq).toNote();
-  const sampler = new Tone.Sampler();
-  sampler.add(rootNote, buffer);
-  sampler.attack = attack;
-  sampler.release = release;
-  sampler.connect(destination);
-  sampler.triggerAttackRelease(note, buffer.duration, startTime, velocity);
-  const disposeTime =
-    (startTime - audioContext.currentTime + buffer.duration + release + 0.5) *
-    1000;
-  setTimeout(() => {
-    try {
-      sampler.disconnect();
-      sampler.dispose();
-    } catch (e) {}
-  }, disposeTime);
-}
+// playWithToneSampler moved to samplerPlayer.js
 
 function animateSamplerPlayhead(node, startFrac, endFrac, duration, attack = 0, release = 0) {
   if (attack + release > duration) {

--- a/samplerPlayer.js
+++ b/samplerPlayer.js
@@ -1,0 +1,33 @@
+export function playWithToneSampler(
+  buffer,
+  baseFreq,
+  freq,
+  startTime,
+  attack,
+  release,
+  velocity,
+  destination,
+) {
+  const source = audioContext.createBufferSource();
+  source.buffer = buffer;
+  source.playbackRate.value = freq / baseFreq;
+
+  const gain = audioContext.createGain();
+  gain.gain.setValueAtTime(0, startTime);
+  gain.gain.linearRampToValueAtTime(velocity, startTime + attack);
+  gain.gain.setTargetAtTime(0, startTime + attack + buffer.duration, release / 4);
+
+  source.connect(gain);
+  gain.connect(destination);
+
+  source.start(startTime, 0, buffer.duration);
+  const stopTime = startTime + buffer.duration + release;
+  source.stop(stopTime);
+
+  setTimeout(() => {
+    try {
+      source.disconnect();
+      gain.disconnect();
+    } catch (e) {}
+  }, (stopTime - audioContext.currentTime + 0.5) * 1000);
+}

--- a/test/samplerPlayer.test.js
+++ b/test/samplerPlayer.test.js
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { playWithToneSampler } from '../samplerPlayer.js';
+
+describe('playWithToneSampler', () => {
+  it('schedules buffer playback with correct rate', () => {
+    const buffer = { duration: 1 };
+    const source = {
+      buffer: null,
+      playbackRate: { value: 0 },
+      connect: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    const gainNode = {
+      gain: {
+        setValueAtTime: vi.fn(),
+        linearRampToValueAtTime: vi.fn(),
+        setTargetAtTime: vi.fn(),
+      },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    const createBufferSource = vi.fn(() => source);
+    const createGain = vi.fn(() => gainNode);
+    globalThis.audioContext = {
+      currentTime: 0,
+      createBufferSource,
+      createGain,
+    };
+    const dest = {};
+
+    playWithToneSampler(buffer, 100, 200, 0, 0.1, 0.2, 0.5, dest);
+
+    expect(createBufferSource).toHaveBeenCalled();
+    expect(source.buffer).toBe(buffer);
+    expect(source.playbackRate.value).toBeCloseTo(2);
+    expect(source.start).toHaveBeenCalledWith(0, 0, buffer.duration);
+    expect(gainNode.connect).toHaveBeenCalledWith(dest);
+  });
+});


### PR DESCRIPTION
## Summary
- Use Web Audio `AudioBufferSourceNode` for sampler playback
- Factor sampler triggering into dedicated `samplerPlayer` helper
- Add unit test covering sampler playback scheduling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab65dd4cac832c8fc31bf2a2f8d57a