### PR TITLE
Connect sampler playback to audio destination

### DIFF
--- a/samplerPlayer.js
+++ b/samplerPlayer.js
@@ -18,7 +18,8 @@ export function playWithToneSampler(
   gain.gain.setTargetAtTime(0, startTime + attack + buffer.duration, release / 4);
 
   source.connect(gain);
-  gain.connect(destination);
+  const dest = destination ?? audioContext.destination;
+  gain.connect(dest);
 
   source.start(startTime, 0, buffer.duration);
   const stopTime = startTime + buffer.duration + release;

--- a/test/samplerPlayer.test.js
+++ b/test/samplerPlayer.test.js
@@ -39,4 +39,38 @@ describe('playWithToneSampler', () => {
     expect(source.start).toHaveBeenCalledWith(0, 0, buffer.duration);
     expect(gainNode.connect).toHaveBeenCalledWith(dest);
   });
+
+  it('connects to audioContext destination by default', () => {
+    const buffer = { duration: 1 };
+    const source = {
+      buffer: null,
+      playbackRate: { value: 0 },
+      connect: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    const gainNode = {
+      gain: {
+        setValueAtTime: vi.fn(),
+        linearRampToValueAtTime: vi.fn(),
+        setTargetAtTime: vi.fn(),
+      },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    const createBufferSource = vi.fn(() => source);
+    const createGain = vi.fn(() => gainNode);
+    const destinationNode = {};
+    globalThis.audioContext = {
+      currentTime: 0,
+      createBufferSource,
+      createGain,
+      destination: destinationNode,
+    };
+
+    playWithToneSampler(buffer, 100, 200, 0, 0.1, 0.2, 0.5);
+
+    expect(gainNode.connect).toHaveBeenCalledWith(destinationNode);
+  });
 });


### PR DESCRIPTION
## Summary
- Default sampler playback to connect to the audio context's destination when no target node is supplied
- Cover sampler playback destination fallback with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab70c4501c832c8b8b7a5589c8c2b6