### PR TITLE
Clamp sampler playback to avoid past start times

### DIFF
--- a/samplerPlayer.js
+++ b/samplerPlayer.js
@@ -12,17 +12,18 @@ export function playWithToneSampler(
   source.buffer = buffer;
   source.playbackRate.value = freq / baseFreq;
 
+  const dest = destination ?? audioContext.destination;
   const gain = audioContext.createGain();
-  gain.gain.setValueAtTime(0, startTime);
-  gain.gain.linearRampToValueAtTime(velocity, startTime + attack);
-  gain.gain.setTargetAtTime(0, startTime + attack + buffer.duration, release / 4);
+  const actualStart = Math.max(audioContext.currentTime, startTime);
+  gain.gain.setValueAtTime(0, actualStart);
+  gain.gain.linearRampToValueAtTime(velocity, actualStart + attack);
+  gain.gain.setTargetAtTime(0, actualStart + attack + buffer.duration, release / 4);
 
   source.connect(gain);
-  const dest = destination ?? audioContext.destination;
   gain.connect(dest);
 
-  source.start(startTime, 0, buffer.duration);
-  const stopTime = startTime + buffer.duration + release;
+  source.start(actualStart, 0, buffer.duration);
+  const stopTime = actualStart + buffer.duration + release;
   source.stop(stopTime);
 
   setTimeout(() => {

--- a/test/samplerPlayer.test.js
+++ b/test/samplerPlayer.test.js
@@ -73,4 +73,37 @@ describe('playWithToneSampler', () => {
 
     expect(gainNode.connect).toHaveBeenCalledWith(destinationNode);
   });
+
+  it('clamps start time to currentTime when scheduled in the past', () => {
+    const buffer = { duration: 1 };
+    const source = {
+      buffer: null,
+      playbackRate: { value: 0 },
+      connect: vi.fn(),
+      start: vi.fn(),
+      stop: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    const gainNode = {
+      gain: {
+        setValueAtTime: vi.fn(),
+        linearRampToValueAtTime: vi.fn(),
+        setTargetAtTime: vi.fn(),
+      },
+      connect: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    const createBufferSource = vi.fn(() => source);
+    const createGain = vi.fn(() => gainNode);
+    globalThis.audioContext = {
+      currentTime: 1,
+      createBufferSource,
+      createGain,
+    };
+
+    playWithToneSampler(buffer, 100, 100, 0.5, 0.1, 0.2, 0.5, {});
+
+    expect(source.start).toHaveBeenCalledWith(1, 0, buffer.duration);
+    expect(gainNode.gain.setValueAtTime).toHaveBeenCalledWith(0, 1);
+  });
 });


### PR DESCRIPTION
## Summary
- prevent sampler playback from scheduling in the past by clamping start times
- add tests for sampler start time clamping

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68ab7b934f7c832ca22f38bee6956421