### PR TITLE
Improve sampler orb logging and playback handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -4639,6 +4639,15 @@ export function triggerNodeEffect(
               Math.max(0.001, targetSamplerIndividualPeak),
             );
             if (targetSamplerIndividualPeak < 0.001 || noteVolumeFactor === 0) {
+              console.warn(
+                `[Sampler Trigger] Skipping due to low volume`,
+                {
+                  nodeId: node.id,
+                  freq,
+                  noteVolumeFactor,
+                  targetSamplerIndividualPeak,
+                },
+              );
               return;
             }
             const samplerAttack = params.sampleAttack ?? 0.005;
@@ -4647,6 +4656,13 @@ export function triggerNodeEffect(
               lowPassFilter && lowPassFilter.input
                 ? lowPassFilter.input
                 : lowPassFilter;
+            console.log('[Sampler Trigger]', {
+              nodeId: node.id,
+              samplerId,
+              freq,
+              startTime: scheduledStartTime,
+              velocity: targetSamplerIndividualPeak,
+            });
             playWithToneSampler(
               bufferToUse,
               definition.baseFreq,
@@ -4674,6 +4690,11 @@ export function triggerNodeEffect(
             }
           });
       } else {
+        console.warn('[Sampler Trigger] Definition not ready', {
+          samplerId,
+          isLoaded: definition?.isLoaded,
+          hasBuffer: !!definition?.buffer,
+        });
         if (oscillator1 && oscillator1.frequency) {
           const fallbackFreq =
             effectivePitch * Math.pow(2, params.osc1Octave || 0);

--- a/samplerPlayer.js
+++ b/samplerPlayer.js
@@ -53,8 +53,12 @@ export function playWithToneSampler(
   const gain = ctx.createGain();
   const now = ctx.currentTime;
   const actualStart = Math.max(now, startTime);
+  const safeVelocity = Number.isFinite(velocity) && velocity > 0 ? velocity : 0.001;
+  if (safeVelocity !== velocity) {
+    console.warn('[playWithToneSampler] Invalid velocity, using', safeVelocity);
+  }
   gain.gain.setValueAtTime(0, actualStart);
-  gain.gain.linearRampToValueAtTime(velocity, actualStart + attack);
+  gain.gain.linearRampToValueAtTime(safeVelocity, actualStart + attack);
   gain.gain.setTargetAtTime(0, actualStart + attack + buffer.duration, release / 4);
 
   source.connect(gain);
@@ -74,7 +78,7 @@ export function playWithToneSampler(
     actualStart,
     stopTime,
     rate,
-    velocity,
+    velocity: safeVelocity,
   });
 
   setTimeout(() => {


### PR DESCRIPTION
## Summary
- add detailed sampler trigger logs and warnings for missing definitions
- guard against invalid velocities in sampler playback and log adjustments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac219d9f74832c87585a4c31eb04d3