### PR TITLE
Create audio nodes for sampler orbs

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ import { showAnalogOrbMenu, hideAnalogOrbMenu, hideTonePanel } from './orbs/anal
 import { showToneFmSynthMenu } from './orbs/tone-fm-synth-ui.js';
 import * as Tone from 'tone';
 import { playWithToneSampler } from './samplerPlayer.js';
+import { createSamplerOrbAudioNodes } from './orbs/sampler-orb.js';
 import { sanitizeWaveformType } from './utils/oscillatorUtils.js';
 import { morphShape } from './utils/fmShapeMorph.js';
 import { DEFAULT_RESONAUTER_PARAMS, resonauterGranParams, createResonauterOrbAudioNodes, playResonauterSound } from './orbs/resonauter-orb.js';
@@ -2420,7 +2421,9 @@ export function createAudioNodesForNode(node) {
 
           return audioNodes;
     } else if (node.type === "sound") {
-        if (node.audioParams && node.audioParams.engine === 'tonefm') {
+        if (node.audioParams?.waveform && node.audioParams.waveform.startsWith('sampler_')) {
+            return createSamplerOrbAudioNodes(node);
+        } else if (node.audioParams && node.audioParams.engine === 'tonefm') {
             return createToneFmSynthOrb(node);
         } else if (node.audioParams && node.audioParams.engine === 'tone') {
             return createAnalogOrb(node);

--- a/orbs/sampler-orb.js
+++ b/orbs/sampler-orb.js
@@ -1,0 +1,59 @@
+import { DEFAULT_REVERB_SEND, DEFAULT_DELAY_SEND } from '../utils/appConstants.js';
+
+export function createSamplerOrbAudioNodes(node) {
+  const ctx = globalThis.audioContext;
+  if (!ctx) return null;
+  const p = node.audioParams || {};
+
+  const filter = ctx.createBiquadFilter();
+  filter.type = 'lowpass';
+  filter.frequency.value = p.filterCutoff ?? 4000;
+  filter.Q.value = p.filterResonance ?? 1.0;
+
+  const gainNode = ctx.createGain();
+  gainNode.gain.value = 0;
+  filter.connect(gainNode);
+
+  const reverbSendGain = ctx.createGain();
+  reverbSendGain.gain.value = p.reverbSend ?? DEFAULT_REVERB_SEND;
+  gainNode.connect(reverbSendGain);
+  if (globalThis.isReverbReady && globalThis.reverbPreDelayNode) {
+    reverbSendGain.connect(globalThis.reverbPreDelayNode);
+  }
+
+  const delaySendGain = ctx.createGain();
+  delaySendGain.gain.value = p.delaySend ?? DEFAULT_DELAY_SEND;
+  gainNode.connect(delaySendGain);
+  if (globalThis.isDelayReady && globalThis.masterDelaySendGain) {
+    delaySendGain.connect(globalThis.masterDelaySendGain);
+  }
+
+  let mistSendGain;
+  if (globalThis.mistEffectInput) {
+    mistSendGain = ctx.createGain();
+    mistSendGain.gain.value = 0;
+    gainNode.connect(mistSendGain);
+    mistSendGain.connect(globalThis.mistEffectInput);
+  }
+
+  let crushSendGain;
+  if (globalThis.crushEffectInput) {
+    crushSendGain = ctx.createGain();
+    crushSendGain.gain.value = 0;
+    gainNode.connect(crushSendGain);
+    crushSendGain.connect(globalThis.crushEffectInput);
+  }
+
+  if (globalThis.masterGain) {
+    gainNode.connect(globalThis.masterGain);
+  }
+
+  return {
+    lowPassFilter: filter,
+    gainNode,
+    reverbSendGain,
+    delaySendGain,
+    mistSendGain,
+    crushSendGain,
+  };
+}

--- a/samplerPlayer.js
+++ b/samplerPlayer.js
@@ -1,4 +1,4 @@
-export function playWithToneSampler(
+export async function playWithToneSampler(
   buffer,
   baseFreq,
   freq,
@@ -26,9 +26,8 @@ export function playWithToneSampler(
   if (ctx.state !== 'running') {
     console.warn('[playWithToneSampler] AudioContext state is', ctx.state);
     try {
-      ctx.resume().then(() => {
-        console.log('[playWithToneSampler] AudioContext resumed');
-      });
+      await ctx.resume();
+      console.log('[playWithToneSampler] AudioContext resumed');
     } catch (e) {
       console.error('[playWithToneSampler] Failed to resume AudioContext', e);
       return;


### PR DESCRIPTION
## Summary
- build and wire sampler-specific audio node graph so sampler orbs can trigger through filters and effects
- wait for AudioContext to resume before scheduling sampler playback

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ac38af266c832cbb35e31001ea3903