### PR TITLE
Fix sampler scanline overflow

### DIFF
--- a/main.js
+++ b/main.js
@@ -8873,12 +8873,16 @@ function animateSamplerPlayhead(node, startFrac, endFrac, duration, attack = 0, 
     clearTimeout(samplerPlayheadTimeout);
     samplerPlayheadTimeout = null;
   }
+  // Clamp fractions to keep the playhead within the display bounds
+  const clampedStart = Math.min(Math.max(startFrac, 0), 1);
+  const clampedEnd = Math.min(Math.max(endFrac, 0), 1);
+
   samplerVisualPlayhead.style.transition = "none";
   samplerVisualPlayhead.style.display = "block";
-  samplerVisualPlayhead.style.left = `${startFrac * 100}%`;
+  samplerVisualPlayhead.style.left = `${clampedStart * 100}%`;
   void samplerVisualPlayhead.offsetWidth;
   samplerVisualPlayhead.style.transition = `left ${duration}s linear`;
-  samplerVisualPlayhead.style.left = `${endFrac * 100}%`;
+  samplerVisualPlayhead.style.left = `${clampedEnd * 100}%`;
   if (samplerEnvelopeDot) {
     const startTime = performance.now();
     const step = () => {

--- a/style.css
+++ b/style.css
@@ -727,6 +727,7 @@ body { margin: 0; overflow: hidden; color: var(--text-color); font-family: syste
 .tape-loop-handle.end { right: -3px; border-top-right-radius: 2px; border-bottom-right-radius: 2px; }
 .tape-loop-handle:hover { background-color: rgba(255,255,255,.9); }
 .tape-visual-playhead { position: absolute; top: 0; left: 0; width: 2px; height: 100%; background-color: #ff6060; box-shadow: 0 0 3px #ff6060; z-index: 3; transition: left .05s linear; }
+.op1-display { position: relative; overflow: hidden; }
 .sampler-visual-playhead { position: absolute; top: 0; left: 0; width: 2px; height: 100%; background-color: #ff6060; box-shadow: 0 0 3px #ff6060; z-index: 2; }
 .sampler-envelope-dot { position: absolute; left: 50%; width: 6px; height: 6px; margin-left: -3px; margin-top: -3px; border-radius: 50%; background-color: #ff6060; box-shadow: 0 0 3px #ff6060; pointer-events: none; }
 .cassette-reels { display: flex; justify-content: space-around; align-items: center; width: 100%; }


### PR DESCRIPTION
## Summary
- Keep sampler playhead within bounds by clamping start/end fractions
- Ensure sampler display clips playhead with relative positioning and hidden overflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac596462b8832c8b3a91253405e2ef