### PR TITLE
Add per-orb bitcrusher to sampler

### DIFF
--- a/main.js
+++ b/main.js
@@ -4369,6 +4369,14 @@ export function triggerNodeEffect(
     const orbitoneModulatorGains = audioNodes.orbitoneModulatorGains;
     const orbitoneIndividualGains = audioNodes.orbitoneIndividualGains;
     const osc1Gain = audioNodes.osc1Gain;
+    const bitCrusherWetGain = audioNodes.bitCrusherWetGain;
+    const bitCrusherDryGain = audioNodes.bitCrusherDryGain;
+
+    if (bitCrusherWetGain && bitCrusherDryGain && params.sampleCrush !== undefined) {
+      const amt = Math.max(0, Math.min(1, params.sampleCrush));
+      bitCrusherWetGain.gain.setTargetAtTime(amt, now, generalUpdateTimeConstant);
+      bitCrusherDryGain.gain.setTargetAtTime(1 - amt, now, generalUpdateTimeConstant);
+    }
 
     if (!isSampler && node.audioParams && node.audioParams.engine === 'tonefm') {
       node.isTriggered = true;
@@ -21116,7 +21124,8 @@ function showSamplerOrbMenu(node) {
         {id:'sampleEnd',min:0,max:1,label:'END'},
         {id:'sampleAttack',min:0,max:1,label:'F.IN'},
         {id:'sampleRelease',min:0,max:1.5,label:'F.OUT'},
-        {id:'sampleGain',min:0,max:2,label:'VOL'}
+        {id:'sampleGain',min:0,max:2,label:'VOL'},
+        {id:'sampleCrush',min:0,max:1,label:'CRSH'}
     ];
     samplerSliders = {};
     controls.forEach(info => {
@@ -22816,6 +22825,7 @@ function addNode(x, y, type, subtype = null, optionalDimensions = null) {
         sampleRelease: 0.2,
         sampleGain: 1.0,
         sampleReverse: false,
+        sampleCrush: 0,
       });
     }
 

--- a/orbs/sampler-orb.js
+++ b/orbs/sampler-orb.js
@@ -1,4 +1,37 @@
-import { DEFAULT_REVERB_SEND, DEFAULT_DELAY_SEND } from '../utils/appConstants.js';
+import {
+  DEFAULT_REVERB_SEND,
+  DEFAULT_DELAY_SEND,
+  CRUSH_BIT_DEPTH,
+  CRUSH_REDUCTION,
+} from '../utils/appConstants.js';
+
+function createBitCrusherNode(bits, normFreq) {
+  const proc = globalThis.audioContext.createScriptProcessor(256, 2, 2);
+  let ph = 0;
+  let lastL = 0,
+    lastR = 0;
+  const step = Math.pow(0.5, bits);
+  proc.onaudioprocess = (e) => {
+    const inL = e.inputBuffer.getChannelData(0);
+    const inR =
+      e.inputBuffer.numberOfChannels > 1
+        ? e.inputBuffer.getChannelData(1)
+        : inL;
+    const outL = e.outputBuffer.getChannelData(0);
+    const outR = e.outputBuffer.getChannelData(1);
+    for (let i = 0; i < inL.length; i++) {
+      ph += normFreq;
+      if (ph >= 1.0) {
+        ph -= 1.0;
+        lastL = step * Math.floor(inL[i] / step + 0.5);
+        lastR = step * Math.floor(inR[i] / step + 0.5);
+      }
+      outL[i] = lastL;
+      outR[i] = lastR;
+    }
+  };
+  return proc;
+}
 
 export function createSamplerOrbAudioNodes(node) {
   const ctx = globalThis.audioContext;
@@ -10,9 +43,20 @@ export function createSamplerOrbAudioNodes(node) {
   filter.frequency.value = p.filterCutoff ?? 4000;
   filter.Q.value = p.filterResonance ?? 1.0;
 
+  const crusher = createBitCrusherNode(CRUSH_BIT_DEPTH, CRUSH_REDUCTION);
+  const bitCrusherWetGain = ctx.createGain();
+  bitCrusherWetGain.gain.value = p.sampleCrush ?? 0;
+  const bitCrusherDryGain = ctx.createGain();
+  bitCrusherDryGain.gain.value = 1 - (p.sampleCrush ?? 0);
+
+  filter.connect(crusher);
+  crusher.connect(bitCrusherWetGain);
+  filter.connect(bitCrusherDryGain);
+
   const gainNode = ctx.createGain();
   gainNode.gain.value = 0;
-  filter.connect(gainNode);
+  bitCrusherWetGain.connect(gainNode);
+  bitCrusherDryGain.connect(gainNode);
 
   const reverbSendGain = ctx.createGain();
   reverbSendGain.gain.value = p.reverbSend ?? DEFAULT_REVERB_SEND;
@@ -55,5 +99,8 @@ export function createSamplerOrbAudioNodes(node) {
     delaySendGain,
     mistSendGain,
     crushSendGain,
+    bitCrusherWetGain,
+    bitCrusherDryGain,
+    bitCrusher: crusher,
   };
 }

--- a/test/samplerOrbBitcrusher.test.js
+++ b/test/samplerOrbBitcrusher.test.js
@@ -1,0 +1,31 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { createSamplerOrbAudioNodes } from '../orbs/sampler-orb.js';
+
+describe('createSamplerOrbAudioNodes bitcrusher', () => {
+  it('applies sampleCrush to wet/dry gains', () => {
+    const ctx = {
+      createBiquadFilter: vi.fn(() => ({
+        type: '',
+        frequency: { value: 0 },
+        Q: { value: 0 },
+        connect: vi.fn(),
+      })),
+      createGain: vi.fn(() => ({
+        gain: {
+          value: 0,
+          setValueAtTime: vi.fn(),
+          setTargetAtTime: vi.fn(),
+          linearRampToValueAtTime: vi.fn(),
+        },
+        connect: vi.fn(),
+      })),
+      createScriptProcessor: vi.fn(() => ({ connect: vi.fn() })),
+    };
+    globalThis.audioContext = ctx;
+    const node = { audioParams: { sampleCrush: 0.4 } };
+    const audioNodes = createSamplerOrbAudioNodes(node);
+    expect(audioNodes.bitCrusherWetGain.gain.value).toBeCloseTo(0.4);
+    expect(audioNodes.bitCrusherDryGain.gain.value).toBeCloseTo(0.6);
+  });
+});


### PR DESCRIPTION
## Summary
- integrate bitcrusher node with wet/dry mix into sampler orbs
- allow adjusting crush amount from sampler UI and defaults
- cover bitcrusher mix with new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac5f9944f4832c959721fa87b19a18