### PR TITLE
feat: add grid pulsar

### DIFF
--- a/main.js
+++ b/main.js
@@ -1204,9 +1204,14 @@ const pulsarTypes = [
     icon: "🛸",
   },
   {
-    type: "pulsar_meteorshower", 
-    label: "Meteor Shower",     
-    icon: "☄️",                 
+    type: "pulsar_meteorshower",
+    label: "Meteor Shower",
+    icon: "☄️",
+  },
+  {
+    type: "pulsar_grid",
+    label: "Grid",
+    icon: "🔳",
   },
 ];
 

--- a/pulsar.js
+++ b/pulsar.js
@@ -1,3 +1,5 @@
+import * as Tone from "tone";
+
 export class Pulse {
   constructor(x, y, angle, speed = 5) {
     this.x = x;
@@ -23,5 +25,61 @@ export class Pulsar {
 
   shoot(angle = 0) {
     return new Pulse(this.x, this.y, angle);
+  }
+}
+
+export class GridPulsar {
+  constructor(
+    x,
+    y,
+    rows = 4,
+    cols = 4,
+    { interval = "8n", sync = true } = {}
+  ) {
+    this.x = x;
+    this.y = y;
+    this.rows = rows;
+    this.cols = cols;
+    this.interval = interval;
+    this.sync = sync;
+    this.grid = Array.from({ length: rows }, () => Array(cols).fill(false));
+    this.column = 0;
+    this.connectors = Array.from({ length: rows }, () => []);
+    this.loop = null;
+  }
+
+  toggle(row, col, state = true) {
+    if (row < 0 || row >= this.rows || col < 0 || col >= this.cols) return;
+    this.grid[row][col] = state;
+  }
+
+  on(row, callback) {
+    if (row < 0 || row >= this.rows) return;
+    this.connectors[row].push(callback);
+  }
+
+  step(time) {
+    const pulses = [];
+    for (let r = 0; r < this.rows; r++) {
+      if (this.grid[r][this.column]) {
+        const pulse = new Pulse(this.x, this.y, 0);
+        pulses.push(pulse);
+        for (const cb of this.connectors[r]) cb(pulse, time);
+      }
+    }
+    this.column = (this.column + 1) % this.cols;
+    return pulses;
+  }
+
+  start() {
+    if (this.loop) return;
+    this.loop = new Tone.Loop((time) => this.step(time), this.interval);
+    if (this.sync) this.loop.start(0);
+    else this.loop.start();
+    if (Tone.Transport.state !== "started") Tone.Transport.start();
+  }
+
+  stop() {
+    if (this.loop) this.loop.stop();
   }
 }

--- a/test/gridPulsar.test.js
+++ b/test/gridPulsar.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GridPulsar } from '../pulsar.js';
+
+describe('GridPulsar', () => {
+  it('emits pulses for active cells as sequencer steps', () => {
+    const grid = new GridPulsar(0, 0, 2, 2, { sync: false });
+    const cb0 = vi.fn();
+    const cb1 = vi.fn();
+    grid.on(0, cb0);
+    grid.on(1, cb1);
+    grid.toggle(0, 1, true);
+    grid.toggle(1, 0, true);
+
+    grid.step();
+    expect(cb1).toHaveBeenCalledOnce();
+    expect(cb0).not.toHaveBeenCalled();
+
+    grid.step();
+    expect(cb0).toHaveBeenCalledOnce();
+    expect(cb1).toHaveBeenCalledOnce();
+  });
+
+  it('wraps around after last column', () => {
+    const grid = new GridPulsar(0, 0, 1, 2, { sync: false });
+    const cb = vi.fn();
+    grid.on(0, cb);
+    grid.toggle(0, 0, true);
+
+    grid.step();
+    expect(cb).toHaveBeenCalledOnce();
+
+    grid.step();
+    grid.step();
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add GridPulsar that sequences across a configurable matrix
- expose per-row callbacks to emit pulses when steps are active
- test GridPulsar step wrapping and pulse emission
- add Grid Pulsar type to toolbar selection

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad481604f4832c9569a928b709938e