### PR TITLE
feat: add grid pulsar

### DIFF
--- a/main.js
+++ b/main.js
@@ -417,6 +417,10 @@ const GRID_SEQUENCER_DEFAULT_WIDTH = 200;
 const GRID_SEQUENCER_DEFAULT_HEIGHT = 150;
 const GRID_SEQUENCER_DEFAULT_ROWS = 4;
 const GRID_SEQUENCER_DEFAULT_COLS = 8;
+const GRID_PULSAR_DEFAULT_WIDTH = 200;
+const GRID_PULSAR_DEFAULT_HEIGHT = 150;
+const GRID_PULSAR_DEFAULT_ROWS = 4;
+const GRID_PULSAR_DEFAULT_COLS = 4;
 const SPACERADAR_MODE_NORMAL = "normal";
 const SPACERADAR_MODE_REVERSE = "reverse";
 const SPACERADAR_DEFAULT_MODE = SPACERADAR_MODE_NORMAL;
@@ -1204,9 +1208,14 @@ const pulsarTypes = [
     icon: "🛸",
   },
   {
-    type: "pulsar_meteorshower", 
-    label: "Meteor Shower",     
-    icon: "☄️",                 
+    type: "pulsar_meteorshower",
+    label: "Meteor Shower",
+    icon: "☄️",
+  },
+  {
+    type: "pulsar_grid",
+    label: "Grid",
+    icon: "🔳",
   },
 ];
 
@@ -1366,7 +1375,7 @@ function updateAllConnectionLengths() {
 function findNodeAt(worldX, worldY) {
   for (let i = nodes.length - 1; i >= 0; i--) {
     const n = nodes[i];
-    if (n.type === TIMELINE_GRID_TYPE || n.type === GRID_SEQUENCER_TYPE) {
+    if (n.type === TIMELINE_GRID_TYPE || n.type === GRID_SEQUENCER_TYPE || n.type === "pulsar_grid") {
       const rectX1 = n.x - n.width / 2;
       const rectY1 = n.y - n.height / 2;
       const rectX2 = n.x + n.width / 2;
@@ -11094,6 +11103,52 @@ function drawNode(node) {
       node.audioParams.color !== null
         ? node.audioParams.color
         : gridBoxStrokeFromCSSTimeline;
+  } else if (node.type === "pulsar_grid") {
+    const rectX = node.x - node.width / 2;
+    const rectY = node.y - node.height / 2;
+    const currentStyles = getComputedStyle(document.documentElement);
+    const gridStroke =
+      currentStyles
+        .getPropertyValue("--timeline-grid-default-border-color")
+        .trim() || "rgba(220, 220, 220, 0.8)";
+    const internalColor =
+      currentStyles
+        .getPropertyValue("--timeline-grid-internal-lines-color")
+        .trim() || gridStroke.replace(/[\d\.]+\)$/g, "0.3)");
+
+    ctx.fillStyle = gridStroke.replace(/[\d\.]+\)$/g, "0.05)");
+    ctx.fillRect(rectX, rectY, node.width, node.height);
+
+    ctx.strokeStyle = gridStroke;
+    ctx.lineWidth = Math.max(1 / viewScale, 2 / viewScale);
+    ctx.strokeRect(rectX, rectY, node.width, node.height);
+
+    ctx.strokeStyle = internalColor;
+    ctx.lineWidth = Math.max(0.5 / viewScale, 1 / viewScale);
+    for (let i = 1; i < (node.cols || GRID_PULSAR_DEFAULT_COLS); i++) {
+      const x = rectX + (i * node.width) / (node.cols || GRID_PULSAR_DEFAULT_COLS);
+      ctx.beginPath();
+      ctx.moveTo(x, rectY);
+      ctx.lineTo(x, rectY + node.height);
+      ctx.stroke();
+    }
+    for (let i = 1; i < (node.rows || GRID_PULSAR_DEFAULT_ROWS); i++) {
+      const y = rectY + (i * node.height) / (node.rows || GRID_PULSAR_DEFAULT_ROWS);
+      ctx.beginPath();
+      ctx.moveTo(rectX, y);
+      ctx.lineTo(rectX + node.width, y);
+      ctx.stroke();
+    }
+
+    const connectorRadius = 5 / viewScale;
+    ctx.fillStyle = gridStroke;
+    for (let r = 0; r < (node.rows || GRID_PULSAR_DEFAULT_ROWS); r++) {
+      const cy = rectY + (r + 0.5) * node.height / (node.rows || GRID_PULSAR_DEFAULT_ROWS);
+      const cx = rectX - connectorRadius * 2;
+      ctx.beginPath();
+      ctx.arc(cx, cy, connectorRadius, 0, Math.PI * 2);
+      ctx.fill();
+    }
   } else if (node.type === GRID_SEQUENCER_TYPE) {
     const currentStylesTimeline = getComputedStyle(document.documentElement);
     const gridBoxStrokeFromCSS =
@@ -13333,6 +13388,18 @@ function drawAddPreview() {
         rows: GRID_SEQUENCER_DEFAULT_ROWS,
         cols: GRID_SEQUENCER_DEFAULT_COLS,
         type: GRID_SEQUENCER_TYPE,
+      };
+      drawNode(previewNode);
+    } else if (nodeTypeToAdd === "pulsar_grid") {
+      const previewNode = {
+        id: -1,
+        x: mousePos.x,
+        y: mousePos.y,
+        width: GRID_PULSAR_DEFAULT_WIDTH,
+        height: GRID_PULSAR_DEFAULT_HEIGHT,
+        rows: GRID_PULSAR_DEFAULT_ROWS,
+        cols: GRID_PULSAR_DEFAULT_COLS,
+        type: "pulsar_grid",
       };
       drawNode(previewNode);
     } else {
@@ -22889,6 +22956,27 @@ function addNode(x, y, type, subtype = null, optionalDimensions = null) {
     newNode.audioParams.rocketSpeed = ROCKET_DEFAULT_SPEED;
     newNode.audioParams.rocketRange = ROCKET_DEFAULT_RANGE;
     newNode.audioParams.rocketGravity = ROCKET_DEFAULT_GRAVITY;
+  }
+
+  if (type === "pulsar_grid") {
+    newNode.width = optionalDimensions
+      ? optionalDimensions.width
+      : GRID_PULSAR_DEFAULT_WIDTH;
+    newNode.height = optionalDimensions
+      ? optionalDimensions.height
+      : GRID_PULSAR_DEFAULT_HEIGHT;
+    newNode.rows = GRID_PULSAR_DEFAULT_ROWS;
+    newNode.cols = GRID_PULSAR_DEFAULT_COLS;
+    newNode.grid = Array.from({ length: newNode.rows }, () =>
+      Array(newNode.cols).fill(false),
+    );
+    newNode.column = 0;
+    if (!newNode.audioParams) newNode.audioParams = {};
+    newNode.audioParams.rows = newNode.rows;
+    newNode.audioParams.cols = newNode.cols;
+    delete newNode.starPoints;
+    delete newNode.baseHue;
+    delete newNode.color;
   }
 
   if (type === TIMELINE_GRID_TYPE) {

--- a/pulsar.js
+++ b/pulsar.js
@@ -1,3 +1,5 @@
+import * as Tone from "tone";
+
 export class Pulse {
   constructor(x, y, angle, speed = 5) {
     this.x = x;
@@ -23,5 +25,61 @@ export class Pulsar {
 
   shoot(angle = 0) {
     return new Pulse(this.x, this.y, angle);
+  }
+}
+
+export class GridPulsar {
+  constructor(
+    x,
+    y,
+    rows = 4,
+    cols = 4,
+    { interval = "8n", sync = true } = {}
+  ) {
+    this.x = x;
+    this.y = y;
+    this.rows = rows;
+    this.cols = cols;
+    this.interval = interval;
+    this.sync = sync;
+    this.grid = Array.from({ length: rows }, () => Array(cols).fill(false));
+    this.column = 0;
+    this.connectors = Array.from({ length: rows }, () => []);
+    this.loop = null;
+  }
+
+  toggle(row, col, state = true) {
+    if (row < 0 || row >= this.rows || col < 0 || col >= this.cols) return;
+    this.grid[row][col] = state;
+  }
+
+  on(row, callback) {
+    if (row < 0 || row >= this.rows) return;
+    this.connectors[row].push(callback);
+  }
+
+  step(time) {
+    const pulses = [];
+    for (let r = 0; r < this.rows; r++) {
+      if (this.grid[r][this.column]) {
+        const pulse = new Pulse(this.x, this.y, 0);
+        pulses.push(pulse);
+        for (const cb of this.connectors[r]) cb(pulse, time);
+      }
+    }
+    this.column = (this.column + 1) % this.cols;
+    return pulses;
+  }
+
+  start() {
+    if (this.loop) return;
+    this.loop = new Tone.Loop((time) => this.step(time), this.interval);
+    if (this.sync) this.loop.start(0);
+    else this.loop.start();
+    if (Tone.Transport.state !== "started") Tone.Transport.start();
+  }
+
+  stop() {
+    if (this.loop) this.loop.stop();
   }
 }

--- a/test/gridPulsar.test.js
+++ b/test/gridPulsar.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GridPulsar } from '../pulsar.js';
+
+describe('GridPulsar', () => {
+  it('emits pulses for active cells as sequencer steps', () => {
+    const grid = new GridPulsar(0, 0, 2, 2, { sync: false });
+    const cb0 = vi.fn();
+    const cb1 = vi.fn();
+    grid.on(0, cb0);
+    grid.on(1, cb1);
+    grid.toggle(0, 1, true);
+    grid.toggle(1, 0, true);
+
+    grid.step();
+    expect(cb1).toHaveBeenCalledOnce();
+    expect(cb0).not.toHaveBeenCalled();
+
+    grid.step();
+    expect(cb0).toHaveBeenCalledOnce();
+    expect(cb1).toHaveBeenCalledOnce();
+  });
+
+  it('wraps around after last column', () => {
+    const grid = new GridPulsar(0, 0, 1, 2, { sync: false });
+    const cb = vi.fn();
+    grid.on(0, cb);
+    grid.toggle(0, 0, true);
+
+    grid.step();
+    expect(cb).toHaveBeenCalledOnce();
+
+    grid.step();
+    grid.step();
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add Grid Pulsar that sequences across a configurable matrix
- expose per-row callbacks to emit pulses when steps are active
- test GridPulsar step wrapping and pulse emission
- add Grid Pulsar type to toolbar selection
- render Grid Pulsar as a grid with connector dots and rectangular hit detection

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad481604f4832c9569a928b709938e