### PR TITLE
feat: add nexusui grid sequencer

### DIFF
--- a/pulsar.js
+++ b/pulsar.js
@@ -1,5 +1,10 @@
 import * as Tone from "tone";
 
+// NexusUI is only available in a browser environment.
+// Use a deferred dynamic import so tests can run in Node
+// without requiring a DOM implementation.
+let NexusPromise = typeof window !== 'undefined' ? import('nexusui') : null;
+
 export class Pulse {
   constructor(x, y, angle, speed = 5) {
     this.x = x;
@@ -34,7 +39,7 @@ export class GridPulsar {
     y,
     rows = 4,
     cols = 4,
-    { interval = "8n", sync = true } = {}
+    { interval = "8n", sync = true, target = null } = {}
   ) {
     this.x = x;
     this.y = y;
@@ -46,11 +51,44 @@ export class GridPulsar {
     this.column = 0;
     this.connectors = Array.from({ length: rows }, () => []);
     this.loop = null;
+    this.sequencer = null;
+
+    if (target && NexusPromise) {
+      NexusPromise.then(({ default: Nexus }) => {
+        this.sequencer = new Nexus.Sequencer(target, {
+          rows,
+          columns: cols,
+          size: [cols * 20, rows * 20],
+        });
+        this.sequencer.on('change', (v) => {
+          let row, col, state;
+          if (Array.isArray(v)) {
+            [row, col, state] = v;
+          } else if (v && typeof v === 'object') {
+            row = v.row;
+            col = v.column;
+            state = v.state;
+          }
+          if (typeof row === 'number' && typeof col === 'number') {
+            this.toggle(row, col, !!state);
+          }
+        });
+      }).catch(() => {
+        /* ignore */
+      });
+    }
   }
 
   toggle(row, col, state = true) {
     if (row < 0 || row >= this.rows || col < 0 || col >= this.cols) return;
     this.grid[row][col] = state;
+    if (this.sequencer) {
+      try {
+        this.sequencer.matrix.set.cell(row, col, state ? 1 : 0);
+      } catch {
+        // ignore if Nexus matrix API is unavailable
+      }
+    }
   }
 
   on(row, callback) {


### PR DESCRIPTION
## Summary
- integrate NexusUI's Sequencer for a toggleable grid
- mirror UI changes into GridPulsar state and feed callbacks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb381dfe4832c86aea7465b195e55