### PR TITLE
Guard against missing element types in edit panel

### DIFF
--- a/main.js
+++ b/main.js
@@ -17848,10 +17848,10 @@ function populateEditPanel() {
 
     if (selectedArray.length === 1) {
         const element =
-            firstElementData.type === "node" ?
-            findNodeById(firstElementData.id) :
-            findConnectionById(firstElementData.id);
-        if (element) {
+            firstElementData.type === "node"
+                ? findNodeById(firstElementData.id)
+                : findConnectionById(firstElementData.id);
+        if (element?.type) {
             logicalType = element.type.replace(/_/g, " ");
             titleText = `Edit ${logicalType} #${element.id}`;
             allSameLogicalType = true;
@@ -17861,9 +17861,14 @@ function populateEditPanel() {
     } else {
         const types = new Set([...nodeTypes, ...connectionTypesSet]);
         if (types.size === 1) {
-            logicalType = [...types][0].replace(/_/g, " ");
-            titleText = `Edit ${selectedArray.length} ${logicalType}s`;
-            allSameLogicalType = true;
+            const onlyType = [...types][0];
+            if (onlyType) {
+                logicalType = onlyType.replace(/_/g, " ");
+                titleText = `Edit ${selectedArray.length} ${logicalType}s`;
+                allSameLogicalType = true;
+            } else {
+                titleText = `Edit ${selectedArray.length} Elements`;
+            }
         } else {
             titleText = `Edit ${selectedArray.length} Elements (Mixed Types)`;
             allSameLogicalType = false;


### PR DESCRIPTION
## Summary
- Avoid TypeError when populating the edit panel with elements lacking a type
- Handle mixed or missing types gracefully when multiple elements are selected

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add3810858832c9e63c0e016c1f010