### PR TITLE
Fix grid sequencer cell toggling

### DIFF
--- a/pulsar.js
+++ b/pulsar.js
@@ -69,7 +69,8 @@ export class GridSequencer {
         for (let r = 0; r < rows; r++) {
           for (let c = 0; c < cols; c++) {
             if (this.grid[r][c]) {
-              this.sequencer.matrix.set.cell(r, c, 1);
+              // Matrix.set.cell expects (column, row, value)
+              this.sequencer.matrix.set.cell(c, r, 1);
             }
           }
         }
@@ -84,7 +85,8 @@ export class GridSequencer {
     this.grid[row][col] = state;
     if (this.sequencer) {
       try {
-        this.sequencer.matrix.set.cell(row, col, state ? 1 : 0);
+        // Matrix.set.cell uses (column, row, value)
+        this.sequencer.matrix.set.cell(col, row, state ? 1 : 0);
       } catch {
         // ignore if Nexus matrix API is unavailable
       }

--- a/test/gridPulsar.test.js
+++ b/test/gridPulsar.test.js
@@ -33,4 +33,14 @@ describe('GridSequencer', () => {
     grid.step();
     expect(cb).toHaveBeenCalledTimes(2);
   });
+
+  it('sets matrix cells using column,row order', () => {
+    const grid = new GridSequencer(0, 0, 2, 2, { sync: false });
+    const setCell = vi.fn();
+    grid.sequencer = { matrix: { set: { cell: setCell } } };
+
+    grid.toggle(1, 0, true);
+
+    expect(setCell).toHaveBeenCalledWith(0, 1, 1);
+  });
 });


### PR DESCRIPTION
## Summary
- correct Nexus matrix coordinate order when toggling grid sequencer cells
- cover matrix coordinate order with a unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68addfd715d0832c8b3a3c1fdf40bfc7