### PR TITLE
feat: add manual advance to grid sequencer

### DIFF
--- a/pulsar.js
+++ b/pulsar.js
@@ -162,6 +162,14 @@ export class GridSequencer {
     this.column = (this.column + 1) % this.cols;
   }
 
+  // Manually advance to the next column and trigger callbacks.
+  // If a specific time is provided, it's passed through to the callbacks.
+  // Otherwise, Tone.now() is used so that the sequence can be stepped
+  // outside of a scheduled Tone.js clock.
+  next(time = Tone.now()) {
+    this.step(time);
+  }
+
   start() {
     if (this.loop) return;
     this.loop = new Tone.Loop((time) => this.step(time), this.interval);

--- a/test/gridPulsar.test.js
+++ b/test/gridPulsar.test.js
@@ -44,6 +44,19 @@ describe('GridSequencer', () => {
     expect(setCell).toHaveBeenCalledWith(0, 1, 1);
   });
 
+  it('manually advances using next()', () => {
+    const grid = new GridSequencer(0, 0, 1, 2, { sync: false });
+    const cb = vi.fn();
+    grid.on(0, cb);
+    grid.toggle(0, 1, true);
+
+    grid.next();
+    expect(cb).not.toHaveBeenCalled();
+
+    grid.next();
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
   it('forces toggle on ctrl+click and prevents dragging', () => {
     const grid = new GridSequencer(0, 0, 2, 2, { sync: false });
     const listeners = {};


### PR DESCRIPTION
## Summary
- add `next()` method to GridSequencer for manual stepping
- test manual advancement of GridSequencer

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68ae02a9a3a8832c83be372d494b4113