### PR TITLE
feat: allow syncing grid sequencer

### DIFF
--- a/test/gridSequencer.test.js
+++ b/test/gridSequencer.test.js
@@ -1,7 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { GridSequencer } from '../gridSequencer.js';
 
 describe('GridSequencer', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    delete globalThis.isGlobalSyncEnabled;
+    delete globalThis.globalBPM;
+  });
+
   it('emits pulses based on pattern', () => {
     vi.useFakeTimers();
     const seq = new GridSequencer(null, { rows: 2, columns: 4, interval: 100 });
@@ -20,5 +26,26 @@ describe('GridSequencer', () => {
       { row: 1, column: 1 },
       { row: 0, column: 3 },
     ]);
+  });
+
+  it('syncs interval to global BPM subdivisions', () => {
+    vi.useFakeTimers();
+    globalThis.isGlobalSyncEnabled = true;
+    globalThis.globalBPM = 120; // 0.5s per beat
+    const seq = new GridSequencer(null, {
+      useGlobalSync: true,
+      subdivision: 0.5, // eighth note
+    });
+    seq.start();
+    expect(seq.interval).toBeCloseTo(250); // 0.25s
+    seq.stop();
+  });
+
+  it('allows changing step count', () => {
+    const seq = new GridSequencer(null, { rows: 1, columns: 4 });
+    expect(seq.columns).toBe(4);
+    seq.setSteps(6);
+    expect(seq.columns).toBe(6);
+    expect(seq.matrix[0]).toHaveLength(6);
   });
 });


### PR DESCRIPTION
## Summary
- allow GridSequencer to sync speed to BPM subdivisions
- support toggling global sync, BPM changes, and step count updates
- expose grid sequencer speed and step controls in the hamburger menu
- cover new behaviours with additional tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae205c5438832ca99c95158c911bd5