### PR TITLE
feat: make grid sequencer scalable and draggable

### DIFF
--- a/gridSequencer.js
+++ b/gridSequencer.js
@@ -29,6 +29,14 @@ export class GridSequencer {
     if (target && NexusPromise) {
       NexusPromise.then(({ default: Nexus }) => {
         this.sequencer = new Nexus.Sequencer(target, { rows, columns });
+        const element =
+          this.sequencer.element || this.sequencer.canvas || target;
+        try {
+          const rect = element.getBoundingClientRect();
+          this.cellSize = rect.height / rows;
+        } catch {
+          this.cellSize = (element?.height || element?.offsetHeight || 0) / rows;
+        }
         this.sequencer.on("change", ({ row, column, state }) => {
           if (row < rows && column < columns) {
             this.matrix[row][column] = state;
@@ -158,6 +166,17 @@ export class GridSequencer {
     this.position = 0;
     if (this.sequencer) {
       try {
+        const element = this.sequencer.element || this.sequencer.canvas;
+        if (element && typeof this.cellSize === "number") {
+          const width = this.cellSize * columns;
+          const height = this.cellSize * this.rows;
+          if (element.width !== undefined) element.width = width;
+          if (element.height !== undefined) element.height = height;
+          if (element.style) {
+            element.style.width = `${width}px`;
+            element.style.height = `${height}px`;
+          }
+        }
         if (typeof this.sequencer.set === "function") {
           this.sequencer.set({ columns, rows: this.rows });
         }

--- a/main.js
+++ b/main.js
@@ -413,11 +413,21 @@ const SPACERADAR_DEFAULT_SPEED = 4.0;
 const SPACERADAR_DEFAULT_COLOR = "rgba(150, 220, 150, 0.7)";
 const SPACERADAR_DEFAULT_PULSE_INTENSITY = 0.9;
 const SPACERADAR_DEFAULT_MUSICAL_BARS = 1;
-const GRID_SEQUENCER_DEFAULT_WIDTH = 200;
 const GRID_SEQUENCER_DEFAULT_HEIGHT = 150;
 const GRID_SEQUENCER_DEFAULT_ROWS = 4;
 const GRID_SEQUENCER_DEFAULT_COLS = 8;
 const GRID_SEQUENCER_DRAG_BORDER = 10;
+function calcGridSequencerWidth(
+  cols,
+  height = GRID_SEQUENCER_DEFAULT_HEIGHT,
+  rows = GRID_SEQUENCER_DEFAULT_ROWS,
+) {
+  const cellSize = (height - GRID_SEQUENCER_DRAG_BORDER * 2) / rows;
+  return cellSize * cols + GRID_SEQUENCER_DRAG_BORDER * 2;
+}
+const GRID_SEQUENCER_DEFAULT_WIDTH = calcGridSequencerWidth(
+  GRID_SEQUENCER_DEFAULT_COLS
+);
 const GRID_PULSAR_DEFAULT_WIDTH = 200;
 const GRID_PULSAR_DEFAULT_HEIGHT = 150;
 const GRID_PULSAR_DEFAULT_ROWS = 4;
@@ -18818,6 +18828,9 @@ function populateEditPanel() {
                                 const oldGrid = n.grid || [];
                                 n.cols = newSteps;
                                 if (n.audioParams) n.audioParams.cols = newSteps;
+                                const border = GRID_SEQUENCER_DRAG_BORDER;
+                                const cellSize = (n.height - border * 2) / rows;
+                                n.width = cellSize * newSteps + border * 2;
                                 const newGrid = Array.from({ length: rows }, (_, r) =>
                                     Array.from({ length: newSteps }, (_, c) =>
                                         (oldGrid[r] && oldGrid[r][c]) || false,


### PR DESCRIPTION
## Summary
- compute grid sequencer width from row height to keep square cells and expose draggable frame
- resize grid sequencer when step count changes so cells stay square
- track cell size and update Nexus sequencer element when steps change

## Testing
- `npm ci`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ae9f8ba950832c9c724b0cb926c09f