### PR TITLE
feat: toggle move/place and align grid with snap

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,7 @@
         <div class="app-menu-separator"></div>
         <button id="app-menu-grid-toggle-btn" class="app-menu-bar-button" title="Toggle Grid Visibility (G)">Grid</button>
         <button id="app-menu-grid-snap-btn" class="app-menu-bar-button" title="Toggle Snap to Grid (N)">Snap</button>
+        <button id="app-menu-move-place-btn" class="app-menu-bar-button" title="Toggle Move/Place Mode (M)">Move</button>
 
         <div class="app-menu-separator"></div>
 

--- a/main.js
+++ b/main.js
@@ -203,6 +203,7 @@ const {
   appMenuReplace,
   appMenuGridToggleBtn,
   appMenuGridSnapBtn,
+  appMenuMovePlaceBtn,
   appMenuSyncToggleBtn,
   appMenuBpmControls,
   appMenuBpmInput,
@@ -10749,8 +10750,9 @@ function drawGrid() {
       .trim() || "rgba(100, 130, 180, 0.15)";
   ctx.lineWidth = 0.5 / viewScale;
   ctx.fillStyle = ctx.strokeStyle;
-  const worldTopLeft = getWorldCoords(0, 0);
-  const worldBottomRight = getWorldCoords(canvas.width, canvas.height);
+  const extra = spacing;
+  const worldTopLeft = getWorldCoords(0, -extra);
+  const worldBottomRight = getWorldCoords(canvas.width, canvas.height + extra);
   const startX = Math.floor(worldTopLeft.x / spacing) * spacing;
   const startY = Math.floor(worldTopLeft.y / spacing) * spacing;
   const endX = Math.ceil(worldBottomRight.x / spacing) * spacing;
@@ -17918,6 +17920,11 @@ function setActiveTool(toolName) {
     updateGroupControlsUI();
     updateRestartPulsarsButtonVisibility();
 
+    if (appMenuMovePlaceBtn) {
+        appMenuMovePlaceBtn.classList.toggle("active", toolName === "add");
+        appMenuMovePlaceBtn.textContent = toolName === "add" ? "Place" : "Move";
+    }
+
     if (toolName === "edit") {
         populateEditPanel();
     } else {
@@ -23845,6 +23852,15 @@ if (appMenuGridSnapBtn) {
   appMenuGridSnapBtn.addEventListener("click", () => {
     isSnapEnabled = !isSnapEnabled;
     appMenuGridSnapBtn.classList.toggle("active", isSnapEnabled);
+  });
+}
+if (appMenuMovePlaceBtn) {
+  appMenuMovePlaceBtn.addEventListener("click", () => {
+    if (currentTool === "add") {
+      setActiveTool("edit");
+    } else {
+      setActiveTool("add");
+    }
   });
 }
 if (appMenuSyncToggleBtn) {

--- a/utils/domElements.js
+++ b/utils/domElements.js
@@ -42,6 +42,7 @@ export const appMenuPaste = safeGetById("app-menu-paste");
 export const appMenuReplace = safeGetById("app-menu-replace");
 export const appMenuGridToggleBtn = safeGetById("app-menu-grid-toggle-btn");
 export const appMenuGridSnapBtn = safeGetById("app-menu-grid-snap-btn");
+export const appMenuMovePlaceBtn = safeGetById("app-menu-move-place-btn");
 export const appMenuSyncToggleBtn = safeGetById("app-menu-sync-toggle-btn");
 export const appMenuBpmControls = safeGetById("app-menu-bpm-controls");
 export const appMenuBpmInput = safeGetById("app-menu-bpm-input");


### PR DESCRIPTION
## Summary
- add app menu toggle to switch between move and place modes
- expand grid drawing vertically so dots align with snap points

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68aeab44b7dc832c8f3ec4dd7dc01735