### PR TITLE
Sync grid sequencer colors with current scale

### DIFF
--- a/main.js
+++ b/main.js
@@ -22142,6 +22142,16 @@ function changeScale(scaleKey, skipNodeUpdate = false) {
   currentScaleKey = scaleKey;
   currentScale = scales[scaleKey];
   document.body.className = currentScale.theme;
+  const rootStyle = document.documentElement?.style;
+  const base = currentScale.baseHSL || { h: 200, s: 70, l: 65 };
+  const startColor = hslToRgba(base.h, base.s, base.l, 0.9);
+  const borderColor = hslToRgba(base.h, base.s, Math.min(100, base.l + 20), 1);
+  if (rootStyle && typeof rootStyle.setProperty === 'function') {
+    rootStyle.setProperty('--start-node-color', startColor);
+    rootStyle.setProperty('--start-node-border', borderColor);
+    rootStyle.setProperty('--timeline-grid-default-scanline-color', startColor);
+    rootStyle.setProperty('--timeline-grid-default-border-color', borderColor);
+  }
   if (scaleSelectTransport) {
       scaleSelectTransport.value = scaleKey;
   }


### PR DESCRIPTION
## Summary
- Update color CSS variables on scale change so grid sequencer reflects current scale

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af02b3202c832cb0ddb51693997088