### PR TITLE
Fix Grid Sequencer color visibility

### DIFF
--- a/gridSequencer.js
+++ b/gridSequencer.js
@@ -31,6 +31,8 @@ export class GridSequencer {
     this.borderAlpha = 1;
     this.activeAlpha = 1;
     this.inactiveAlpha = 1;
+    this.activeColor = "#ffd700";
+    this.inactiveColor = "#222";
 
     if (target && NexusPromise) {
       NexusPromise.then(({ default: Nexus }) => {
@@ -62,6 +64,10 @@ export class GridSequencer {
               pad.setAttribute("stroke-width", "1");
               pad.setAttribute("stroke-opacity", this.borderAlpha);
               pad.setAttribute(
+                "fill",
+                cell.state ? this.activeColor : this.inactiveColor,
+              );
+              pad.setAttribute(
                 "fill-opacity",
                 cell.state ? this.activeAlpha : this.inactiveAlpha,
               );
@@ -85,6 +91,10 @@ export class GridSequencer {
             if (this.sequencer?.cells) {
               const idx = row * this.sequencer.columns + column;
               const pad = this.sequencer.cells[idx].pad;
+              pad.setAttribute(
+                "fill",
+                state ? this.activeColor : this.inactiveColor,
+              );
               pad.setAttribute(
                 "fill-opacity",
                 state ? this.activeAlpha : this.inactiveAlpha,
@@ -151,6 +161,8 @@ export class GridSequencer {
     this.borderAlpha = border.alpha;
     this.activeAlpha = baseActive.alpha;
     this.inactiveAlpha = inactive.alpha;
+    this.activeColor = activeHex;
+    this.inactiveColor = inactive.hex;
 
     this.sequencer.colorize("fill", inactive.hex);
     this.sequencer.colorize("accent", activeHex);


### PR DESCRIPTION
## Summary
- ensure Grid Sequencer pads change fill color when toggled
- derive pad and scanline colors from theme so current step highlight is visible

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68af19de40c0832cbb98cf13dcb4bb7f